### PR TITLE
Reorder nav menu in BitBlazor Stories - Close #41

### DIFF
--- a/stories/BitBlazor.Stories/Components/App.razor
+++ b/stories/BitBlazor.Stories/Components/App.razor
@@ -1,2 +1,5 @@
-<BlazingStoryApp Assemblies="[typeof(App).Assembly, typeof(BitBlazor._Imports).Assembly]">
+@using static BlazingStory.Types.NavigationTreeOrderBuilder
+
+<BlazingStoryApp Assemblies="[typeof(App).Assembly, typeof(BitBlazor._Imports).Assembly]"
+                 NavigationTreeOrder="@N["Welcome"]">
 </BlazingStoryApp>


### PR DESCRIPTION
Reordered the nav menu in BitBlazor Stories, setting as first nav link the "Welcome" page.

Close #41 