### PR TITLE
Add BitModal component and interactive PA showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Once the package is installed, simply add the reference to the Bootstrap Italia 
 <head>
     <!-- other css imports -->
     <link rel="stylesheet" href="_content/BitBlazor/bootstrap-italia/css/bootstrap-italia.min.css" />
+    <!-- optional: include Bootstrap Italia default fonts (Titillium Web, Lora, Roboto Mono) -->
+    <link rel="stylesheet" href="_content/BitBlazor/css/fonts.css" />
 </head>
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,12 +55,19 @@ Specialized badge for use within buttons.
 - Automatic variant inversion
 - Accessibility support
 
+
 #### [Card](components/card.md)
 Complete card system for organizing content.
 - Different types (default, profile, banner)
 - Inline and standard layouts
 - Modular components (header, body, footer, etc.)
 - Support for images and icons
+
+#### [Modal](components/modal.md)
+Modal dialog component for displaying content in an overlay.
+- Accessible dialog overlay
+- Visibility controlled via Blazor state
+- No JavaScript interop required
 
 ### Form Components
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,0 +1,208 @@
+# BitModal
+
+The `BitModal` component provides a [modal dialog using Bootstrap Italia styles](https://italia.github.io/bootstrap-italia/docs/componenti/modale/).
+
+## Namespace
+
+```csharp
+BitBlazor.Components
+```
+
+## Description
+
+The Modal component renders an accessible dialog that overlays the page. Visibility is controlled entirely through Blazor state using the `IsVisible` / `@bind-IsVisible` pattern — no JavaScript interop is required.
+
+## Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `IsVisible` | `bool` | ✗ | `false` | Controls whether the modal is displayed. Use `@bind-IsVisible` for two-way binding. |
+| `IsVisibleChanged` | `EventCallback<bool>` | ✗ | - | Callback invoked when the modal requests a visibility change (close). Wired automatically by `@bind-IsVisible`. |
+| `BodyContent` | `RenderFragment` | ✓ | - | The main body content of the modal. |
+| `Title` | `string?` | ✗ | `null` | Text displayed in the header as an `h2` element. When set, the modal uses `aria-labelledby` for accessibility. |
+| `TitleId` | `string?` | ✗ | `null` | Override for the `id` attribute of the title `h2` element. Defaults to `"{modal-id}-title"`. |
+| `AriaLabel` | `string?` | ✗ | `null` | Sets the `aria-label` on the modal element. Use when `Title` is not set. |
+| `AriaDescribedById` | `string?` | ✗ | `null` | Sets the `aria-describedby` attribute, pointing to a description element inside the modal. |
+| `HeaderContent` | `RenderFragment?` | ✗ | `null` | Fully custom header content, replacing the default `Title`-based header. |
+| `FooterContent` | `RenderFragment?` | ✗ | `null` | Footer content. When `null`, no footer element is rendered. |
+| `ShowCloseButton` | `bool` | ✗ | `true` | Whether to show the close (×) button in the header. |
+| `CloseButtonAriaLabel` | `string` | ✗ | `"Chiudi"` | The `aria-label` for the close button. |
+| `Size` | `ModalSize` | ✗ | `Default` | The size of the modal dialog. |
+| `Position` | `ModalPosition` | ✗ | `Default` | The positioning of the modal dialog. |
+| `Type` | `ModalType` | ✗ | `Default` | The visual type variant of the modal. |
+| `Backdrop` | `ModalBackdrop` | ✗ | `Default` | Controls backdrop visibility and whether clicking it closes the modal. |
+| `ScrollableContent` | `bool` | ✗ | `false` | Enables internal body scrolling, keeping header and footer always visible. |
+| `FooterShadow` | `bool` | ✗ | `false` | Adds a top shadow to the footer element (`modal-footer-shadow`). |
+| `Fade` | `bool` | ✗ | `true` | Enables the CSS fade animation. Set to `false` for instant show/hide. |
+| `OnClose` | `EventCallback` | ✗ | - | Callback invoked just before the modal is closed. |
+
+## Enumerations
+
+### ModalSize
+
+| Value | CSS class on `.modal-dialog` | Description |
+|-------|------------------------------|-------------|
+| `Default` | *(none)* | Standard size |
+| `Small` | `modal-sm` | Small dialog |
+| `Large` | `modal-lg` | Large dialog |
+| `ExtraLarge` | `modal-xl` | Extra-large dialog |
+
+### ModalPosition
+
+| Value | Effect | Description |
+|-------|--------|-------------|
+| `Default` | *(none)* | Top-center (default Bootstrap Italia) |
+| `Centered` | `modal-dialog-centered` on dialog | Vertically centered |
+| `Left` | `modal-dialog-left` on dialog + `it-dialog-scrollable` on modal | Full-height, left-aligned |
+| `Right` | `modal-dialog-right` on dialog + `it-dialog-scrollable` on modal | Full-height, right-aligned |
+
+### ModalType
+
+| Value | CSS class on `.modal` | Description |
+|-------|----------------------|-------------|
+| `Default` | *(none)* | Standard modal |
+| `Alert` | `alert-modal` | Alert modal, used with an icon in the header |
+| `LinkList` | `it-dialog-link-list` | Optimised for navigation link lists |
+| `Popconfirm` | `popconfirm-modal` | Compact confirmation dialog |
+
+### ModalBackdrop
+
+| Value | Description |
+|-------|-------------|
+| `Default` | Backdrop is shown; clicking it closes the modal |
+| `Static` | Backdrop is shown; clicking it does **not** close the modal |
+| `None` | No backdrop is rendered |
+
+## Usage Examples
+
+### Basic modal with two-way binding
+
+```razor
+<button class="btn btn-primary" @onclick="() => isOpen = true">
+    Apri la modale
+</button>
+
+<BitModal @bind-IsVisible="isOpen"
+          Id="example-modal"
+          Title="Intestazione modale"
+          AriaDescribedById="example-modal-desc">
+    <BodyContent>
+        <p id="example-modal-desc">Descrizione scopo della modale.</p>
+        <p>Contenuto della modale.</p>
+    </BodyContent>
+    <FooterContent>
+        <button class="btn btn-outline-primary btn-sm" type="button" @onclick="() => isOpen = false">Annulla</button>
+        <button class="btn btn-primary btn-sm" type="button" @onclick="() => isOpen = false">Conferma</button>
+    </FooterContent>
+</BitModal>
+
+@code {
+    private bool isOpen = false;
+}
+```
+
+### Modal without header
+
+```razor
+<BitModal @bind-IsVisible="isOpen"
+          AriaLabel="Finestra di dialogo"
+          ShowCloseButton="false">
+    <BodyContent>
+        <p>Questa modale non ha intestazione.</p>
+    </BodyContent>
+    <FooterContent>
+        <button class="btn btn-primary btn-sm" @onclick="() => isOpen = false">Chiudi</button>
+    </FooterContent>
+</BitModal>
+```
+
+### Centered modal with scrollable content
+
+```razor
+<BitModal @bind-IsVisible="isOpen"
+          Title="Contenuto lungo"
+          Position="ModalPosition.Centered"
+          ScrollableContent="true"
+          FooterShadow="true">
+    <BodyContent>
+        @* Long content that scrolls inside the modal body *@
+        @for (int i = 1; i <= 20; i++)
+        {
+            <p>Paragrafo @i lorem ipsum dolor sit amet.</p>
+        }
+    </BodyContent>
+    <FooterContent>
+        <button class="btn btn-primary btn-sm" @onclick="() => isOpen = false">OK</button>
+    </FooterContent>
+</BitModal>
+```
+
+### Static backdrop (does not close on click)
+
+```razor
+<BitModal @bind-IsVisible="isOpen"
+          Title="Conferma obbligatoria"
+          Backdrop="ModalBackdrop.Static"
+          ShowCloseButton="false">
+    <BodyContent>
+        <p>Devi fare una scelta per continuare.</p>
+    </BodyContent>
+    <FooterContent>
+        <button class="btn btn-outline-primary btn-sm" @onclick="() => isOpen = false">Annulla</button>
+        <button class="btn btn-primary btn-sm" @onclick="ConfirmAsync">Conferma</button>
+    </FooterContent>
+</BitModal>
+```
+
+### Alert modal with icon
+
+```razor
+<BitModal @bind-IsVisible="isOpen"
+          Type="ModalType.Alert"
+          AriaLabel="Avviso importante">
+    <HeaderContent>
+        <div class="d-flex align-items-center">
+            <BitIcon IconName="@Icons.ItWarningCircle" CssClass="me-2" />
+            <h2 class="modal-title h5 mb-0">Avviso importante</h2>
+        </div>
+    </HeaderContent>
+    <BodyContent>
+        <p>Il documento verrà eliminato definitivamente.</p>
+    </BodyContent>
+    <FooterContent>
+        <button class="btn btn-outline-primary btn-sm" @onclick="() => isOpen = false">Annulla</button>
+        <button class="btn btn-primary btn-sm" @onclick="DeleteAsync">Elimina</button>
+    </FooterContent>
+</BitModal>
+```
+
+### Popconfirm modal
+
+```razor
+<BitModal @bind-IsVisible="isOpen"
+          Type="ModalType.Popconfirm"
+          AriaLabel="Sei sicuro?"
+          ShowCloseButton="false">
+    <BodyContent>
+        <p>Questa operazione non può essere annullata.</p>
+    </BodyContent>
+    <FooterContent>
+        <button class="btn btn-outline-primary btn-sm" @onclick="() => isOpen = false">No</button>
+        <button class="btn btn-primary btn-sm" @onclick="ProceedAsync">Sì, procedi</button>
+    </FooterContent>
+</BitModal>
+```
+
+## Accessibility
+
+- The modal element always carries `role="dialog"` and `aria-modal="true"`.
+- The dialog element carries `role="document"`.
+- When `Title` is set (and `HeaderContent` is not overriding the header), `aria-labelledby` points automatically to the title `h2` element.
+- When there is no `Title`, set `AriaLabel` to provide an accessible name for screen readers.
+- Use `AriaDescribedById` to reference a descriptive paragraph inside the `BodyContent` for a richer screen-reader experience.
+- The close button always has an `aria-label` (defaults to `"Chiudi"`). Customise it with `CloseButtonAriaLabel`.
+
+## References
+
+- [Bootstrap Italia — Finestre modali](https://italia.github.io/bootstrap-italia/docs/componenti/modale/)
+- [WAI-ARIA Authoring Practices — Dialog Modal](https://www.w3.org/TR/wai-aria-practices/#dialog_modal)

--- a/samples/BitBlazor.Sample/BitBlazor.Sample.Client/Pages/Comunicazioni.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample.Client/Pages/Comunicazioni.razor
@@ -1,0 +1,160 @@
+@page "/comunicazioni"
+@rendermode InteractiveAuto
+
+@using BitBlazor.Components
+@using BitBlazor.Utilities
+
+<PageTitle>Comunicazioni — Comune di Bitopoli</PageTitle>
+
+<BitBreadcrumb Items="@breadcrumbItems" />
+
+<div class="mt-3 mb-4">
+    <h1 class="h3 fw-bold mb-1">Comunicazioni e Avvisi</h1>
+    <p class="text-muted mb-0">
+        Tutte le comunicazioni istituzionali, avvisi urgenti e notifiche del Comune di Bitopoli.
+    </p>
+</div>
+
+<!-- Filtri per categoria -->
+<div class="d-flex flex-wrap gap-2 mb-4 align-items-center">
+    <span class="small fw-semibold text-muted me-1">Filtra per:</span>
+    <BitBadge Text="@($"Tutti ({visibleCount})")" BackgroundColor="Color.Primary" Rounded="true" />
+    <BitBadge Text="Urgenti" BackgroundColor="Color.Danger" Rounded="true" />
+    <BitBadge Text="Informativi" BackgroundColor="Color.Primary" Rounded="true" />
+    <BitBadge Text="Successo" BackgroundColor="Color.Success" Rounded="true" />
+</div>
+
+<!-- Notifiche interattive (dismissibili) -->
+<div class="d-flex flex-column gap-3 mb-5">
+
+    @foreach (var item in visibleItems)
+    {
+        <BitCard Bordered="true" Shadow="CardShadow.Small">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start gap-3 mb-2">
+                    <div class="d-flex align-items-center gap-2">
+                        <BitBadge Text="@item.Category" BackgroundColor="@item.BadgeColor" Rounded="true" />
+                        <span class="text-muted small">@item.Date.ToString("dd MMMM yyyy")</span>
+                    </div>
+                    <BitAvatar Text="@item.AvatarText" Size="Size.Small" BackgroundColor="@item.AvatarColor" />
+                </div>
+                <BitAlert Type="@item.AlertType" Title="@item.Title" Dismissible="true"
+                          CloseButtonAriaLabel="Chiudi avviso"
+                          OnClosed="@(() => DismissItem(item.Id))">
+                    <p class="mb-0">@item.Body</p>
+                </BitAlert>
+            </CardBody>
+        </BitCard>
+    }
+
+    @if (!visibleItems.Any())
+    {
+        <BitCard Bordered="true" Shadow="CardShadow.Small">
+            <CardBody>
+                <CardText>
+                    <div class="text-center py-4 text-muted">
+                        <BitIcon IconName="@Icons.ItCheckCircle" Size="IconSize.ExtraLarge" Color="IconColor.Success" />
+                        <p class="mt-3 mb-0">Nessuna comunicazione da visualizzare.<br />Hai chiuso tutti gli avvisi attivi.</p>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    }
+</div>
+
+@if (dismissed.Any())
+{
+    <div class="d-flex align-items-center gap-3 mb-4">
+        <span class="text-muted small">@dismissed.Count avvisi chiusi</span>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" Size="Size.Small" OnClick="RestoreAll">
+            Ripristina tutti
+        </BitButton>
+    </div>
+}
+
+<!-- Storico comunicazioni (statiche) -->
+<h2 class="h5 fw-bold mb-3">Archivio comunicazioni</h2>
+<div class="row g-3">
+    @foreach (var arch in archive)
+    {
+        <div class="col-12 col-md-6">
+            <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+                <CardBody>
+                    <div class="d-flex justify-content-between align-items-start mb-2">
+                        <BitBadge Text="@arch.Category" BackgroundColor="Color.Secondary" Rounded="true" />
+                        <span class="text-muted small">@arch.Date.ToString("dd/MM/yyyy")</span>
+                    </div>
+                    <CardTitle>@arch.Title</CardTitle>
+                    <CardText>
+                        <p class="text-muted small mb-2">@arch.Summary</p>
+                    </CardText>
+                    <CardFooter>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">
+                            Leggi tutto
+                        </BitButton>
+                    </CardFooter>
+                </CardBody>
+            </BitCard>
+        </div>
+    }
+</div>
+
+@code {
+    private List<int> dismissed = new();
+
+    private int visibleCount => visibleItems.Count;
+
+    private List<ComunicazioneItem> allItems = new()
+    {
+        new(1, "Urgente",     AlertType.Danger,  "Allerta meteo — Codice Arancione",
+            "La Protezione Civile ha emesso un'allerta meteo arancione per il comune di Bitopoli valida dalle 18:00 di oggi alle 06:00 di domani. Si raccomanda la massima prudenza.",
+            new DateOnly(2026, 3, 14), "PC", Color.Danger, Color.Danger),
+        new(2, "Lavori",      AlertType.Warning, "Interruzione acqua in Via Mazzini",
+            "Giovedì 19 marzo dalle 08:00 alle 16:00 sarà sospesa l'erogazione idrica in Via Mazzini, Via Garibaldi e vie limitrofe per interventi di manutenzione straordinaria.",
+            new DateOnly(2026, 3, 13), "AM", Color.Warning, Color.Warning),
+        new(3, "Informativo", AlertType.Info,    "Apertura sportello PagoPA",
+            "A partire dal 17 marzo 2026 sarà attivo il nuovo sportello PagoPA per il pagamento online di tutti i tributi e le sanzioni comunali, incluse IMU, TARI e infrazioni stradali.",
+            new DateOnly(2026, 3, 12), "PA", Color.Primary, Color.Primary),
+        new(4, "Avviso",      AlertType.Info,    "Consultazione pubblica PNRR",
+            "È aperta fino al 31 marzo 2026 la consultazione pubblica sul Piano Nazionale di Ripresa e Resilienza — progetti del Comune di Bitopoli. Tutti i cittadini possono partecipare.",
+            new DateOnly(2026, 3, 10), "PN", Color.Secondary, Color.Secondary),
+        new(5, "Servizi",     AlertType.Success, "Nuovo CIE Point operativo",
+            "Da oggi è operativo il nuovo punto di rilascio CIE (Carta d'Identità Elettronica) presso la sede municipale. Tempi di attesa ridotti e prenotazione online disponibile.",
+            new DateOnly(2026, 3, 8),  "CI", Color.Success, Color.Success),
+    };
+
+    private List<ComunicazioneItem> visibleItems =>
+        allItems.Where(i => !dismissed.Contains(i.Id)).ToList();
+
+    private List<ArchivioItem> archive = new()
+    {
+        new("Notizie",  "Approvato il bilancio preventivo 2026",
+            "Il Consiglio Comunale ha approvato il bilancio preventivo per l'anno 2026 con 14 voti favorevoli.",
+            new DateOnly(2026, 2, 28)),
+        new("Turismo",  "Calendario eventi primaverili 2026",
+            "Pubblicato il programma completo degli eventi culturali e turistici del Comune per la stagione primaverile.",
+            new DateOnly(2026, 2, 20)),
+        new("Sociale",  "Bando contributi affitto 2026",
+            "Aperto il bando per la concessione di contributi a fondo perduto per il sostegno al pagamento dei canoni di locazione.",
+            new DateOnly(2026, 2, 15)),
+        new("Ambiente", "Piano rifiuti: nuovi orari raccolta",
+            "A partire dal 1° marzo 2026 variano gli orari e i giorni della raccolta differenziata porta a porta. Consulta il nuovo calendario.",
+            new DateOnly(2026, 2, 10)),
+    };
+
+    private void DismissItem(int id) => dismissed.Add(id);
+
+    private void RestoreAll() => dismissed.Clear();
+
+    private IReadOnlyList<BitBreadcrumbItem> breadcrumbItems = new List<BitBreadcrumbItem>
+    {
+        new BitBreadcrumbItem { Text = "Home", Link = "/" },
+        new BitBreadcrumbItem { Text = "Comunicazioni" }
+    };
+
+    private record ComunicazioneItem(
+        int Id, string Category, AlertType AlertType, string Title, string Body,
+        DateOnly Date, string AvatarText, Color AvatarColor, Color BadgeColor);
+
+    private record ArchivioItem(string Category, string Title, string Summary, DateOnly Date);
+}

--- a/samples/BitBlazor.Sample/BitBlazor.Sample.Client/Pages/Modulistica.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample.Client/Pages/Modulistica.razor
@@ -1,0 +1,291 @@
+@page "/modulistica"
+@rendermode InteractiveAuto
+
+@using BitBlazor.Components
+@using BitBlazor.Utilities
+@using BitBlazor.Form
+
+<PageTitle>Modulistica — Comune di Bitopoli</PageTitle>
+
+<BitBreadcrumb Items="@breadcrumbItems" />
+
+<div class="mt-3 mb-4">
+    <h1 class="h3 fw-bold mb-1">Modulistica Online</h1>
+    <p class="text-muted mb-0">
+        Compila e invia i moduli digitali direttamente dal portale. I dati salvati sono
+        protetti e trasmessi in modo sicuro agli uffici competenti.
+    </p>
+</div>
+
+<div class="row g-4">
+
+    <!-- Colonna sinistra: form -->
+    <div class="col-12 col-lg-8">
+
+        <!-- Sezione: Dati anagrafici -->
+        <BitCard Bordered="true" Shadow="CardShadow.Small" CssClass="mb-4">
+            <CardBody>
+                <CardTitle>Dati Anagrafici</CardTitle>
+                <CardText>
+                    <EditForm Model="@formModel" OnValidSubmit="HandleValidSubmit">
+                        <DataAnnotationsValidator />
+
+                        <div class="row g-3">
+                            <div class="col-12 col-sm-6">
+                                <BitTextField Label="Nome" @bind-Value="formModel.Nome" Placeholder="Inserisci il nome" Required="true" />
+                            </div>
+                            <div class="col-12 col-sm-6">
+                                <BitTextField Label="Cognome" @bind-Value="formModel.Cognome" Placeholder="Inserisci il cognome" Required="true" />
+                            </div>
+                            <div class="col-12 col-sm-6">
+                                <BitTextField Label="Codice Fiscale" @bind-Value="formModel.CodiceFiscale" Placeholder="Es. RSSMRA80A01H501U" Required="true" />
+                            </div>
+                            <div class="col-12 col-sm-6">
+                                <BitTextField Label="Telefono" @bind-Value="formModel.Telefono" Placeholder="+39 000 0000000" />
+                            </div>
+                            <div class="col-12">
+                                <BitTextField Label="Indirizzo email" @bind-Value="formModel.Email" Placeholder="nome@esempio.it" Required="true" />
+                            </div>
+                        </div>
+                    </EditForm>
+                </CardText>
+            </CardBody>
+        </BitCard>
+
+        <!-- Sezione: Tipo di richiesta -->
+        <BitCard Bordered="true" Shadow="CardShadow.Small" CssClass="mb-4">
+            <CardBody>
+                <CardTitle>Tipo di Richiesta</CardTitle>
+                <CardText>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold small">Area di interesse</label>
+                        <BitSelectField @bind-Value="formModel.AreaServizio" Label="Area di servizio" Required="true">
+                            <BitSelectItem Value="@("anagrafe")">Anagrafe e Stato Civile</BitSelectItem>
+                            <BitSelectItem Value="@("tributi")">Tributi e Pagamenti</BitSelectItem>
+                            <BitSelectItem Value="@("edilizia")">Edilizia e Territorio</BitSelectItem>
+                            <BitSelectItem Value="@("suap")">SUAP — Attività Produttive</BitSelectItem>
+                            <BitSelectItem Value="@("sociale")">Servizi Sociali</BitSelectItem>
+                            <BitSelectItem Value="@("ambiente")">Ambiente e Mobilità</BitSelectItem>
+                        </BitSelectField>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold small d-block mb-2">Urgenza della pratica</label>
+                        <BitRadioGroup @bind-Value="formModel.Urgenza">
+                            <BitRadio Value="@("normale")" Label="Normale (15 giorni lavorativi)" />
+                            <BitRadio Value="@("urgente")" Label="Urgente (5 giorni lavorativi) — motivazione richiesta" />
+                            <BitRadio Value="@("immediata")" Label="Immediata — solo certificati base" />
+                        </BitRadioGroup>
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-12 col-sm-6">
+                            <BitDatepicker Label="Data preferita rilascio" @bind-Value="formModel.DataRilascio" />
+                        </div>
+                        <div class="col-12 col-sm-6">
+                            <BitTimepicker Label="Orario preferito" @bind-Value="formModel.OraRilascio" />
+                        </div>
+                    </div>
+
+                    <div class="mt-3">
+                        <BitNumberField Label="Numero di copie richieste" @bind-Value="formModel.NumeroCopie" />
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+
+        <!-- Sezione: Dettaglio richiesta -->
+        <BitCard Bordered="true" Shadow="CardShadow.Small" CssClass="mb-4">
+            <CardBody>
+                <CardTitle>Dettaglio della Richiesta</CardTitle>
+                <CardText>
+                    <div class="mb-3">
+                        <BitTextAreaField Label="Descrizione" @bind-Value="formModel.Descrizione"
+                                          Placeholder="Descrivi la tua richiesta in modo dettagliato..." />
+                    </div>
+
+                    <div class="mb-3">
+                        <BitCheckbox Label="Dichiaro che i dati inseriti sono veritieri ai sensi del D.P.R. 445/2000"
+                                     @bind-Value="formModel.AccettaDichiarazione" Required="true" />
+                    </div>
+                    <div class="mb-3">
+                        <BitCheckbox Label="Acconsento al trattamento dei dati personali ai sensi del Reg. UE 2016/679 (GDPR)"
+                                     @bind-Value="formModel.AccettaPrivacy" Required="true" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold small d-block mb-2">
+                            Modalità di consegna
+                        </label>
+                        <BitToggle Label="Consegna digitale via email" @bind-Value="formModel.ConsegnaDigitale" />
+                        <div class="mt-2">
+                            <BitToggle Label="Notifica via SMS" @bind-Value="formModel.NotificaSMS" />
+                        </div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+
+        <!-- Pulsanti invio -->
+        <div class="d-flex gap-3 flex-wrap">
+            <BitButton Color="Color.Primary" Size="Size.Large" OnClick="HandleValidSubmit" Disabled="@(!IsFormValid)">
+                <BitIcon IconName="@Icons.ItUpload" />
+                Invia Richiesta
+            </BitButton>
+            <BitButton Color="Color.Secondary" Variant="Variant.Outline" Size="Size.Large" OnClick="ResetForm">
+                Azzera modulo
+            </BitButton>
+        </div>
+
+        @if (submitted)
+        {
+            <div class="mt-4">
+                <BitAlert Type="AlertType.Success" Title="Richiesta inviata con successo!">
+                    <p class="mb-0">
+                        Il tuo numero di protocollo è <strong>#@protocolNumber</strong>.
+                        Riceverai una conferma all'indirizzo <strong>@formModel.Email</strong>
+                        entro pochi minuti.
+                    </p>
+                </BitAlert>
+            </div>
+        }
+    </div>
+
+    <!-- Colonna destra: riepilogo e info -->
+    <div class="col-12 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" CssClass="mb-4">
+            <CardBody>
+                <CardTitle>Riepilogo Richiesta</CardTitle>
+                <CardText>
+                    <dl class="small mb-0">
+                        <dt class="text-muted">Richiedente</dt>
+                        <dd class="mb-2">
+                            @if (!string.IsNullOrWhiteSpace(formModel.Nome) || !string.IsNullOrWhiteSpace(formModel.Cognome))
+                            {
+                                <span>@formModel.Nome @formModel.Cognome</span>
+                            }
+                            else
+                            {
+                                <span class="text-muted fst-italic">—</span>
+                            }
+                        </dd>
+                        <dt class="text-muted">Area</dt>
+                        <dd class="mb-2">
+                            @if (!string.IsNullOrWhiteSpace(formModel.AreaServizio))
+                            {
+                                <BitBadge Text="@areaLabel" BackgroundColor="Color.Primary" Rounded="true" />
+                            }
+                            else
+                            {
+                                <span class="text-muted fst-italic">—</span>
+                            }
+                        </dd>
+                        <dt class="text-muted">Urgenza</dt>
+                        <dd class="mb-2">
+                            @if (!string.IsNullOrWhiteSpace(formModel.Urgenza))
+                            {
+                                @formModel.Urgenza
+                            }
+                            else
+                            {
+                                <span class="text-muted fst-italic">—</span>
+                            }
+                        </dd>
+                        <dt class="text-muted">Copie</dt>
+                        <dd class="mb-0">@formModel.NumeroCopie</dd>
+                    </dl>
+                </CardText>
+            </CardBody>
+        </BitCard>
+
+        <BitCard Bordered="true" Shadow="CardShadow.Small">
+            <CardBody>
+                <CardTitle>Orari Sportello</CardTitle>
+                <CardText>
+                    <ul class="list-unstyled small mb-0">
+                        <li class="mb-1 d-flex justify-content-between">
+                            <span class="text-muted">Lunedì – Mercoledì</span>
+                            <span>09:00 – 13:00</span>
+                        </li>
+                        <li class="mb-1 d-flex justify-content-between">
+                            <span class="text-muted">Giovedì</span>
+                            <span>09:00 – 17:00</span>
+                        </li>
+                        <li class="mb-1 d-flex justify-content-between">
+                            <span class="text-muted">Venerdì</span>
+                            <span>09:00 – 12:00</span>
+                        </li>
+                        <li class="d-flex justify-content-between">
+                            <span class="text-muted">Sabato – Domenica</span>
+                            <span>Chiuso</span>
+                        </li>
+                    </ul>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+
+</div>
+
+@code {
+    private FormModel formModel = new();
+    private bool submitted = false;
+    private string protocolNumber = string.Empty;
+
+    private bool IsFormValid =>
+        !string.IsNullOrWhiteSpace(formModel.Nome) &&
+        !string.IsNullOrWhiteSpace(formModel.Cognome) &&
+        !string.IsNullOrWhiteSpace(formModel.Email) &&
+        formModel.AccettaDichiarazione &&
+        formModel.AccettaPrivacy;
+
+    private string areaLabel => formModel.AreaServizio switch
+    {
+        "anagrafe" => "Anagrafe",
+        "tributi"  => "Tributi",
+        "edilizia" => "Edilizia",
+        "suap"     => "SUAP",
+        "sociale"  => "Sociale",
+        "ambiente" => "Ambiente",
+        _          => formModel.AreaServizio ?? string.Empty
+    };
+
+    private void HandleValidSubmit()
+    {
+        if (!IsFormValid) return;
+        protocolNumber = $"BIT-{DateTime.Now:yyyyMMdd}-{Random.Shared.Next(1000, 9999)}";
+        submitted = true;
+    }
+
+    private void ResetForm()
+    {
+        formModel = new();
+        submitted = false;
+        protocolNumber = string.Empty;
+    }
+
+    private IReadOnlyList<BitBreadcrumbItem> breadcrumbItems = new List<BitBreadcrumbItem>
+    {
+        new BitBreadcrumbItem { Text = "Home", Link = "/" },
+        new BitBreadcrumbItem { Text = "Modulistica" }
+    };
+
+    private class FormModel
+    {
+        public string? Nome { get; set; }
+        public string? Cognome { get; set; }
+        public string? CodiceFiscale { get; set; }
+        public string? Telefono { get; set; }
+        public string? Email { get; set; }
+        public string? AreaServizio { get; set; }
+        public string? Urgenza { get; set; } = "normale";
+        public DateOnly? DataRilascio { get; set; }
+        public TimeOnly? OraRilascio { get; set; }
+        public int NumeroCopie { get; set; } = 1;
+        public string? Descrizione { get; set; }
+        public bool AccettaDichiarazione { get; set; }
+        public bool AccettaPrivacy { get; set; }
+        public bool ConsegnaDigitale { get; set; } = true;
+        public bool NotificaSMS { get; set; }
+    }
+}

--- a/samples/BitBlazor.Sample/BitBlazor.Sample.Client/Pages/Sportello.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample.Client/Pages/Sportello.razor
@@ -1,0 +1,477 @@
+@page "/sportello"
+@rendermode InteractiveAuto
+
+@using BitBlazor.Components
+@using BitBlazor.Utilities
+
+<PageTitle>Sportello Digitale — Comune di Bitopoli</PageTitle>
+
+<BitBreadcrumb Items="@breadcrumbItems" />
+
+<div class="mt-3 mb-4">
+    <h1 class="h3 fw-bold mb-1">Sportello Digitale</h1>
+    <p class="text-muted mb-0">
+        Prenota un appuntamento, avvia una pratica urgente o contatta direttamente
+        un operatore. I nostri sportelli digitali sono disponibili 24 ore su 24.
+    </p>
+</div>
+
+<!-- KPI sportello -->
+<div class="row g-3 mb-4">
+    <div class="col-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardText>
+                    <div class="text-center py-2">
+                        <div class="fs-2 fw-bold text-primary">@ticketNumber</div>
+                        <div class="small text-muted">Il tuo numero</div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardText>
+                    <div class="text-center py-2">
+                        <div class="fs-2 fw-bold text-success">@calledNumber</div>
+                        <div class="small text-muted">Numero chiamato</div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardText>
+                    <div class="text-center py-2">
+                        <div class="fs-2 fw-bold @(waitCount > 5 ? "text-danger" : "text-warning")">@waitCount</div>
+                        <div class="small text-muted">In attesa</div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardText>
+                    <div class="text-center py-2">
+                        <div class="fs-2 fw-bold text-info">~@waitMinutes min</div>
+                        <div class="small text-muted">Attesa stimata</div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+</div>
+
+<!-- Azioni principali -->
+<div class="row g-3 mb-5">
+    <div class="col-12 col-md-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardTitle>Prenota Sportello</CardTitle>
+                <CardText>
+                    <p class="text-muted small">
+                        Salta la fila! Prenota il tuo slot in uno degli sportelli fisici e
+                        arriva puntuale senza attese.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <BitButton Color="Color.Primary" OnClick="@(() => OpenModal("prenota"))">
+                        <BitIcon IconName="@Icons.ItCalendar" />
+                        Prenota ora
+                    </BitButton>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardTitle>Pratica Urgente</CardTitle>
+                <CardText>
+                    <p class="text-muted small">
+                        Hai bisogno di un documento con urgenza? Invia una richiesta di
+                        trattazione prioritaria motivata.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <BitButton Color="Color.Danger" Variant="Variant.Outline" OnClick="@(() => OpenModal("urgente"))">
+                        <BitIcon IconName="@Icons.ItError" />
+                        Richiesta urgente
+                    </BitButton>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardTitle>Contatta Operatore</CardTitle>
+                <CardText>
+                    <p class="text-muted small">
+                        Parla direttamente con un operatore per chiarimenti su pratiche in
+                        corso o per ricevere assistenza.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => OpenModal("contatta"))">
+                        <BitIcon IconName="@Icons.ItMail" />
+                        Contatta ora
+                    </BitButton>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+</div>
+
+<!-- Showcase modale: varianti -->
+<h2 class="h5 fw-bold mb-3">Varianti BitModal</h2>
+<div class="row g-3 mb-4">
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Primary" Variant="Variant.Outline" OnClick="@(() => OpenModal("default"))">
+            Modale Base
+        </BitButton>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Primary" Variant="Variant.Outline" OnClick="@(() => OpenModal("centered"))">
+            Verticalmente centrata
+        </BitButton>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Warning" Variant="Variant.Outline" OnClick="@(() => OpenModal("alert"))">
+            Modale Alert
+        </BitButton>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => OpenModal("popconfirm"))">
+            Popconfirm
+        </BitButton>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small" OnClick="@(() => OpenModal("small"))">
+            Piccola
+        </BitButton>
+        <BitButton Color="Color.Primary" Variant="Variant.Outline" CssClass="ms-2" OnClick="@(() => OpenModal("large"))">
+            Grande
+        </BitButton>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => OpenModal("left"))">
+            ← Sinistra
+        </BitButton>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" CssClass="ms-2" OnClick="@(() => OpenModal("right"))">
+            Destra →
+        </BitButton>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Primary" Variant="Variant.Outline" OnClick="@(() => OpenModal("scrollable"))">
+            Contenuto lungo
+        </BitButton>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitButton Color="Color.Danger" Variant="Variant.Outline" OnClick="@(() => OpenModal("static"))">
+            Backdrop statico
+        </BitButton>
+    </div>
+</div>
+
+<!-- ===== MODALI ===== -->
+
+<!-- Prenota Sportello -->
+<BitModal @bind-IsVisible="showPrenota" Title="Prenota uno Sportello" Size="ModalSize.Large">
+    <BodyContent>
+        <p>Seleziona il giorno e lo sportello di tua preferenza per prenotare un appuntamento.</p>
+        <div class="row g-3">
+            <div class="col-12 col-sm-6">
+                <label class="form-label fw-semibold small">Sportello</label>
+                <select class="form-select">
+                    <option>Anagrafe — Piano terra</option>
+                    <option>Tributi — Primo piano</option>
+                    <option>Edilizia — Secondo piano</option>
+                    <option>SUAP — Via Garibaldi 5</option>
+                </select>
+            </div>
+            <div class="col-12 col-sm-6">
+                <label class="form-label fw-semibold small">Motivo visita</label>
+                <select class="form-select">
+                    <option>Rilascio certificato</option>
+                    <option>Variazione dati anagrafici</option>
+                    <option>Pagamento tributi</option>
+                    <option>Consulenza pratica edilizia</option>
+                </select>
+            </div>
+        </div>
+        <div class="row g-3 mt-1">
+            <div class="col-12 col-sm-4">
+                <label class="form-label fw-semibold small">Data</label>
+                <input type="date" class="form-control" min="@DateTime.Today.ToString("yyyy-MM-dd")" />
+            </div>
+            <div class="col-12 col-sm-4">
+                <label class="form-label fw-semibold small">Orario</label>
+                <select class="form-select">
+                    <option>09:00</option><option>09:30</option><option>10:00</option>
+                    <option>10:30</option><option>11:00</option><option>11:30</option>
+                    <option>14:00</option><option>14:30</option><option>15:00</option>
+                </select>
+            </div>
+            <div class="col-12 col-sm-4">
+                <label class="form-label fw-semibold small">Persone</label>
+                <input type="number" class="form-control" value="1" min="1" max="3" />
+            </div>
+        </div>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" OnClick="ConfirmPrenotazione">Conferma prenotazione</BitButton>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => showPrenota = false)">Annulla</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Pratica Urgente -->
+<BitModal @bind-IsVisible="showUrgente" Title="Richiesta Pratica Urgente" Type="ModalType.Alert">
+    <BodyContent>
+        <div class="d-flex align-items-start gap-3">
+            <BitIcon IconName="@Icons.ItError" Color="IconColor.Danger" Size="IconSize.Large" />
+            <div>
+                <p class="mb-2">
+                    Le pratiche urgenti sono soggette a valutazione da parte dell'ufficio competente.
+                    La tua richiesta verrà presa in carico entro <strong>24 ore</strong>.
+                </p>
+                <p class="mb-0 text-muted small">
+                    Inserisci la motivazione dell'urgenza. La richiesta priva di valida motivazione
+                    verrà respinta automaticamente.
+                </p>
+            </div>
+        </div>
+        <div class="mt-3">
+            <label class="form-label fw-semibold small">Motivazione urgenza <span class="text-danger">*</span></label>
+            <textarea class="form-control" rows="3" placeholder="Descrivi il motivo dell'urgenza..."></textarea>
+        </div>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Danger" OnClick="@(() => { showUrgente = false; showConfirmAlert = true; })">
+            Invia richiesta urgente
+        </BitButton>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => showUrgente = false)">Annulla</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Contatta Operatore -->
+<BitModal @bind-IsVisible="showContatta" Title="Contatta un Operatore">
+    <BodyContent>
+        <p class="text-muted small mb-3">
+            Scrivi il tuo messaggio. Un operatore ti risponderà all'indirizzo email indicato
+            entro il prossimo giorno lavorativo.
+        </p>
+        <div class="mb-3">
+            <label class="form-label fw-semibold small">Oggetto</label>
+            <input type="text" class="form-control" placeholder="Es. Chiarimenti pratica #BIT-20260310-1234" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label fw-semibold small">Messaggio</label>
+            <textarea class="form-control" rows="4" placeholder="Descrivi dettagliatamente la tua richiesta..."></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label fw-semibold small">La tua email</label>
+            <input type="email" class="form-control" placeholder="nome@esempio.it" />
+        </div>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" OnClick="@(() => showContatta = false)">Invia messaggio</BitButton>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => showContatta = false)">Chiudi</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Conferma dopo pratica urgente -->
+<BitModal @bind-IsVisible="showConfirmAlert" Title="Richiesta inviata" Type="ModalType.Popconfirm" Size="ModalSize.Small">
+    <BodyContent>
+        <div class="d-flex align-items-center gap-2">
+            <BitIcon IconName="@Icons.ItCheckCircle" Color="IconColor.Success" />
+            <span>Richiesta urgente registrata con successo!</span>
+        </div>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" Size="Size.Small" OnClick="@(() => showConfirmAlert = false)">OK</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale base -->
+<BitModal @bind-IsVisible="showDefault" Title="Modale Base" Size="ModalSize.Default">
+    <BodyContent>
+        <p>Questa è una modale base con titolo, corpo e footer. Supporta header/body/footer customizzabili tramite <code>RenderFragment</code>.</p>
+        <p class="mb-0">Clicca fuori o sul pulsante Chiudi per chiuderla.</p>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" Variant="Variant.Outline" OnClick="@(() => showDefault = false)">Chiudi</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale centrata -->
+<BitModal @bind-IsVisible="showCentered" Title="Centratura Verticale" Position="ModalPosition.Centered">
+    <BodyContent>
+        <p>Questa modale è centrata verticalmente nella viewport grazie a <code>Position="ModalPosition.Centered"</code>.</p>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" OnClick="@(() => showCentered = false)">Chiudi</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale alert -->
+<BitModal @bind-IsVisible="showAlert" Title="Avviso di sistema" Type="ModalType.Alert">
+    <BodyContent>
+        <p>Variante <code>Type="ModalType.Alert"</code> — usata per messaggi importanti che richiedono attenzione dell'utente come avvisi critici del sistema.</p>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Warning" OnClick="@(() => showAlert = false)">Ho capito</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Popconfirm -->
+<BitModal @bind-IsVisible="showPopconfirm" Title="Conferma azione" Type="ModalType.Popconfirm" Size="ModalSize.Small">
+    <BodyContent>
+        <p class="mb-0">Vuoi davvero annullare la pratica #BIT-2026-0042?</p>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Danger" Size="Size.Small" OnClick="@(() => showPopconfirm = false)">Sì, annulla</BitButton>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" Size="Size.Small" OnClick="@(() => showPopconfirm = false)">No</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale piccola -->
+<BitModal @bind-IsVisible="showSmall" Title="Modale piccola" Size="ModalSize.Small">
+    <BodyContent><p>Variante <code>ModalSize.Small</code>.</p></BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" Size="Size.Small" OnClick="@(() => showSmall = false)">OK</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale grande -->
+<BitModal @bind-IsVisible="showLarge" Title="Modale grande" Size="ModalSize.Large">
+    <BodyContent><p>Variante <code>ModalSize.Large</code> — adatta per contenuti più articolati come tabelle, form complessi o dettagli documento.</p></BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" Variant="Variant.Outline" OnClick="@(() => showLarge = false)">Chiudi</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale sinistra -->
+<BitModal @bind-IsVisible="showLeft" Title="Pannello laterale sinistro" Position="ModalPosition.Left" ScrollableContent="true">
+    <BodyContent>
+        <p>Pannello che si apre da sinistra a destra (<code>ModalPosition.Left</code>). Utile per menu contestuali e drawer di navigazione.</p>
+        <ul>
+            <li>Dettagli pratica</li>
+            <li>Documenti allegati</li>
+            <li>Storico modifiche</li>
+            <li>Note operatore</li>
+        </ul>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => showLeft = false)">Chiudi</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale destra -->
+<BitModal @bind-IsVisible="showRight" Title="Pannello laterale destro" Position="ModalPosition.Right" ScrollableContent="true">
+    <BodyContent>
+        <p>Pannello che si apre da destra a sinistra (<code>ModalPosition.Right</code>). Adatto per pannelli di dettaglio e configurazione.</p>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => showRight = false)">Chiudi</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale contenuto lungo -->
+<BitModal @bind-IsVisible="showScrollable" Title="Documento — Regolamento Edilizio" Size="ModalSize.Large" ScrollableContent="true" FooterShadow="true">
+    <BodyContent>
+        <p><strong>Art. 1 — Oggetto e finalità</strong><br />
+        Il presente regolamento disciplina le modalità di presentazione, istruttoria e conclusione dei procedimenti edilizi nel territorio del Comune di Bitopoli, ai sensi del D.P.R. 380/2001 e s.m.i.</p>
+        <p><strong>Art. 2 — Definizioni</strong><br />
+        Ai fini del presente regolamento si intende per "intervento edilizio" qualsiasi trasformazione fisica o funzionale del territorio...</p>
+        <p><strong>Art. 3 — Permesso di costruire</strong><br />
+        Sono subordinati a permesso di costruire gli interventi di nuova costruzione, gli interventi di ristrutturazione urbanistica e gli interventi di ristrutturazione edilizia che portino ad un organismo edilizio in tutto o in parte diverso dal precedente...</p>
+        <p><strong>Art. 4 — CILA e SCIA</strong><br />
+        La Comunicazione di Inizio Lavori Asseverata (CILA) è richiesta per interventi di manutenzione straordinaria ove non riguardino parti strutturali...</p>
+        <p><strong>Art. 5 — Contributi di costruzione</strong><br />
+        Il rilascio del permesso di costruire comporta la corresponsione di un contributo commisurato all'incidenza degli oneri di urbanizzazione nonché al costo di costruzione...</p>
+        <p><strong>Art. 6 — Procedimento</strong><br />
+        Il procedimento per il rilascio del permesso di costruire si svolge secondo le disposizioni di cui all'art. 20 del D.P.R. 380/2001...</p>
+        <p class="mb-0"><strong>Art. 7 — Sanzioni</strong><br />
+        Chiunque esegua interventi edilizi in assenza del prescritto titolo abilitativo è soggetto alle sanzioni di cui agli artt. 31 e seguenti del D.P.R. 380/2001.</p>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" OnClick="@(() => showScrollable = false)">
+            <BitIcon IconName="@Icons.ItDownload" /> Scarica PDF
+        </BitButton>
+        <BitButton Color="Color.Secondary" Variant="Variant.Outline" OnClick="@(() => showScrollable = false)">Chiudi</BitButton>
+    </FooterContent>
+</BitModal>
+
+<!-- Modale backdrop statico -->
+<BitModal @bind-IsVisible="showStatic" Title="Sessione protetta" Backdrop="ModalBackdrop.Static">
+    <BodyContent>
+        <p>Questo dialogo ha <code>Backdrop="ModalBackdrop.Static"</code>: cliccando fuori non si chiude. Devi usare il pulsante per procedere.</p>
+        <BitAlert Type="AlertType.Warning">
+            <p class="mb-0">La sessione scadrà tra <strong>4:58</strong>. Salva il tuo lavoro.</p>
+        </BitAlert>
+    </BodyContent>
+    <FooterContent>
+        <BitButton Color="Color.Primary" OnClick="@(() => showStatic = false)">Rinnova sessione</BitButton>
+        <BitButton Color="Color.Danger" Variant="Variant.Outline" OnClick="@(() => showStatic = false)">Esci</BitButton>
+    </FooterContent>
+</BitModal>
+
+@code {
+    // Dati sportello
+    private int ticketNumber = 47;
+    private int calledNumber = 38;
+    private int waitCount = 9;
+    private int waitMinutes => waitCount * 5;
+
+    // Visibilità modali
+    private bool showPrenota;
+    private bool showUrgente;
+    private bool showContatta;
+    private bool showConfirmAlert;
+    private bool showDefault;
+    private bool showCentered;
+    private bool showAlert;
+    private bool showPopconfirm;
+    private bool showSmall;
+    private bool showLarge;
+    private bool showLeft;
+    private bool showRight;
+    private bool showScrollable;
+    private bool showStatic;
+
+    private void OpenModal(string type)
+    {
+        showPrenota = type == "prenota";
+        showUrgente = type == "urgente";
+        showContatta = type == "contatta";
+        showDefault = type == "default";
+        showCentered = type == "centered";
+        showAlert = type == "alert";
+        showPopconfirm = type == "popconfirm";
+        showSmall = type == "small";
+        showLarge = type == "large";
+        showLeft = type == "left";
+        showRight = type == "right";
+        showScrollable = type == "scrollable";
+        showStatic = type == "static";
+    }
+
+    private void ConfirmPrenotazione()
+    {
+        ticketNumber++;
+        showPrenota = false;
+    }
+
+    private IReadOnlyList<BitBreadcrumbItem> breadcrumbItems = new List<BitBreadcrumbItem>
+    {
+        new BitBreadcrumbItem { Text = "Home", Link = "/" },
+        new BitBreadcrumbItem { Text = "Sportello Digitale" }
+    };
+}

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/App.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/App.razor
@@ -7,6 +7,7 @@
     <base href="/" />
     <ResourcePreloader />
     <link rel="stylesheet" href="@Assets["_content/BitBlazor/bootstrap-italia/css/bootstrap-italia.min.css"]" />
+    <link rel="stylesheet" href="_content/BitBlazor/css/fonts.css" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["BitBlazor.Sample.styles.css"]" />
     <ImportMap />

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/MainLayout.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/MainLayout.razor
@@ -1,23 +1,43 @@
 ﻿@inherits LayoutComponentBase
 
-<div class="page">
-    <div class="sidebar">
-        <NavMenu />
-    </div>
-
-    <main>
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+<div class="portal-wrapper">
+    <header class="portal-header">
+        <div class="container-fluid px-4">
+            <div class="d-flex align-items-center py-2 gap-3">
+                <a href="/" class="portal-brand text-decoration-none d-flex align-items-center gap-3 me-auto">
+                    <div class="portal-logo">
+                        <BitIcon IconName="@Icons.ItPa" Color="IconColor.White" Size="IconSize.Large" />
+                    </div>
+                    <div>
+                        <div class="portal-brand-title">Comune di Bitopoli</div>
+                        <div class="portal-brand-subtitle d-none d-sm-block">Portale dei Servizi Digitali al Cittadino</div>
+                    </div>
+                </a>
+                <div class="d-flex align-items-center gap-2">
+                    <BitAvatar Text="OS" Size="Size.Small" BackgroundColor="Color.Secondary" />
+                    <div class="d-none d-md-block">
+                        <div class="portal-username">Utente Ospite</div>
+                        <div class="portal-userstatus">Non autenticato</div>
+                    </div>
+                </div>
+            </div>
         </div>
+    </header>
 
-        <article class="content px-4">
-            @Body
-        </article>
-    </main>
+    <div class="portal-body">
+        <nav class="portal-sidebar">
+            <NavMenu />
+        </nav>
+        <main class="portal-main">
+            <article class="portal-content">
+                @Body
+            </article>
+        </main>
+    </div>
 </div>
 
 <div id="blazor-error-ui" data-nosnippet>
-    An unhandled error has occurred.
-    <a href="." class="reload">Reload</a>
+    Si è verificato un errore imprevisto.
+    <a href="." class="reload">Ricarica</a>
     <span class="dismiss">🗙</span>
 </div>

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/MainLayout.razor.css
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/MainLayout.razor.css
@@ -1,16 +1,138 @@
-.page {
-    position: relative;
+/* =========================================
+   Portal wrapper & layout
+   ========================================= */
+.portal-wrapper {
     display: flex;
     flex-direction: column;
+    min-height: 100vh;
 }
 
-main {
+/* =========================================
+   Header
+   ========================================= */
+.portal-header {
+    background-color: #06c;
+    color: white;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-bottom: 3px solid #004d99;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.portal-brand-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: white;
+    line-height: 1.2;
+}
+
+.portal-brand-subtitle {
+    font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.3;
+}
+
+.portal-logo {
+    width: 2.6rem;
+    height: 2.6rem;
+    background-color: rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.portal-username {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: white;
+    line-height: 1.2;
+}
+
+.portal-userstatus {
+    font-size: 0.68rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+/* =========================================
+   Body: sidebar + main
+   ========================================= */
+.portal-body {
+    display: flex;
     flex: 1;
 }
 
-.sidebar {
-    background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+.portal-sidebar {
+    width: 256px;
+    min-width: 256px;
+    background-color: #fff;
+    border-right: 1px solid #e0e0e0;
+    min-height: calc(100vh - 64px);
+    flex-shrink: 0;
 }
+
+.portal-main {
+    flex: 1;
+    background-color: #f4f5f6;
+    min-width: 0;
+}
+
+.portal-content {
+    max-width: 1200px;
+    padding: 2rem 1.5rem;
+}
+
+/* =========================================
+   Utility overrides
+   ========================================= */
+.stat-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+/* =========================================
+   Error UI
+   ========================================= */
+#blazor-error-ui {
+    color-scheme: light only;
+    background: #fff3f3;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.15);
+    box-sizing: border-box;
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+    color: #b20000;
+    border-top: 2px solid #e00;
+}
+
+    #blazor-error-ui .dismiss {
+        cursor: pointer;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.5rem;
+    }
+
+/* =========================================
+   Responsive
+   ========================================= */
+@media (max-width: 991.98px) {
+    .portal-sidebar {
+        display: none;
+    }
+
+    .portal-content {
+        padding: 1rem;
+    }
+}
+
 
 .top-row {
     background-color: #f7f7f7;

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor
@@ -2,71 +2,64 @@
 
 @inject NavigationManager NavigationManager
 
-<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">BitBlazor.Sample</a>
-    </div>
-</div>
+<div class="sidebar-nav">
+    <div class="sidebar-section-title">Servizi al Cittadino</div>
 
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+    <NavLink class="sidebar-nav-link" href="" Match="NavLinkMatch.All">
+        <BitIcon IconName="@Icons.ItPa" />
+        <span>Dashboard</span>
+    </NavLink>
 
-<div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
-    <nav class="nav flex-column">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
+    <NavLink class="sidebar-nav-link" href="servizi">
+        <BitIcon IconName="@Icons.ItFolder" />
+        <span>Servizi</span>
+    </NavLink>
+
+    <NavLink class="sidebar-nav-link" href="modulistica">
+        <BitIcon IconName="@Icons.ItNote" />
+        <span>Modulistica</span>
+    </NavLink>
+
+    <NavLink class="sidebar-nav-link" href="comunicazioni">
+        <BitIcon IconName="@Icons.ItMail" />
+        <span>Comunicazioni</span>
+        <BitBadge Text="3" BackgroundColor="Color.Danger" Rounded="true" CssClass="ms-auto" />
+    </NavLink>
+
+    <NavLink class="sidebar-nav-link" href="sportello">
+        <BitIcon IconName="@Icons.ItCard" />
+        <span>Sportello Digitale</span>
+    </NavLink>
+
+    <div class="sidebar-divider"></div>
+    <div class="sidebar-section-title">Account</div>
+
+    <AuthorizeView>
+        <Authorized>
+            <NavLink class="sidebar-nav-link" href="Account/Manage">
+                <BitIcon IconName="@Icons.ItUser" />
+                <span>@context.User.Identity?.Name</span>
             </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="counter">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Counter
+            <form action="Account/Logout" method="post">
+                <AntiforgeryToken />
+                <input type="hidden" name="ReturnUrl" value="@currentUrl" />
+                <button type="submit" class="sidebar-nav-link">
+                    <BitIcon IconName="@Icons.ItClose" />
+                    <span>Disconnetti</span>
+                </button>
+            </form>
+        </Authorized>
+        <NotAuthorized>
+            <NavLink class="sidebar-nav-link" href="Account/Register">
+                <BitIcon IconName="@Icons.ItUser" />
+                <span>Registrati</span>
             </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="weather">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
+            <NavLink class="sidebar-nav-link" href="Account/Login">
+                <BitIcon IconName="@Icons.ItSettings" />
+                <span>Accedi</span>
             </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="auth">
-                <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Auth Required
-            </NavLink>
-        </div>
-
-        <AuthorizeView>
-            <Authorized>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="Account/Manage">
-                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> @context.User.Identity?.Name
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <form action="Account/Logout" method="post">
-                        <AntiforgeryToken />
-                        <input type="hidden" name="ReturnUrl" value="@currentUrl" />
-                        <BitButton Type="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Outline" CssClass="nav-link">
-                            <span class="bi bi-arrow-bar-left-nav-menu" aria-hidden="true"></span> Logout
-                        </BitButton>
-                    </form>
-                </div>
-            </Authorized>
-            <NotAuthorized>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="Account/Register">
-                        <span class="bi bi-person-nav-menu" aria-hidden="true"></span> Register
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="Account/Login">
-                        <span class="bi bi-person-badge-nav-menu" aria-hidden="true"></span> Login
-                    </NavLink>
-                </div>
-            </NotAuthorized>
-        </AuthorizeView>
-    </nav>
+        </NotAuthorized>
+    </AuthorizeView>
 </div>
 
 @code {

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor
@@ -2,64 +2,89 @@
 
 @inject NavigationManager NavigationManager
 
-<div class="sidebar-nav">
-    <div class="sidebar-section-title">Servizi al Cittadino</div>
+<div class="sidebar-wrapper">
 
-    <NavLink class="sidebar-nav-link" href="" Match="NavLinkMatch.All">
-        <BitIcon IconName="@Icons.ItPa" />
-        <span>Dashboard</span>
-    </NavLink>
+    <div class="sidebar-linklist-wrapper">
+        <div class="link-list-wrapper">
+            <ul class="link-list">
+                <li><h3>Servizi al Cittadino</h3></li>
+                <li>
+                    <NavLink class="list-item medium" href="" Match="NavLinkMatch.All">
+                        <BitIcon IconName="@Icons.ItPa" />
+                        <span>Dashboard</span>
+                    </NavLink>
+                </li>
+                <li>
+                    <NavLink class="list-item medium" href="servizi">
+                        <BitIcon IconName="@Icons.ItFolder" />
+                        <span>Servizi</span>
+                    </NavLink>
+                </li>
+                <li>
+                    <NavLink class="list-item medium" href="modulistica">
+                        <BitIcon IconName="@Icons.ItNote" />
+                        <span>Modulistica</span>
+                    </NavLink>
+                </li>
+                <li>
+                    <NavLink class="list-item medium" href="comunicazioni">
+                        <BitIcon IconName="@Icons.ItMail" />
+                        <span>Comunicazioni</span>
+                        <BitBadge Text="3" BackgroundColor="Color.Danger" Rounded="true" CssClass="ms-auto" />
+                    </NavLink>
+                </li>
+                <li>
+                    <NavLink class="list-item medium" href="sportello">
+                        <BitIcon IconName="@Icons.ItCard" />
+                        <span>Sportello Digitale</span>
+                    </NavLink>
+                </li>
+            </ul>
+        </div>
+    </div>
 
-    <NavLink class="sidebar-nav-link" href="servizi">
-        <BitIcon IconName="@Icons.ItFolder" />
-        <span>Servizi</span>
-    </NavLink>
+    <div class="sidebar-linklist-wrapper linklist-secondary">
+        <div class="link-list-wrapper">
+            <ul class="link-list">
+                <li><h3>Account</h3></li>
+                <AuthorizeView>
+                    <Authorized>
+                        <li>
+                            <NavLink class="list-item medium" href="Account/Manage">
+                                <BitIcon IconName="@Icons.ItUser" />
+                                <span>@context.User.Identity?.Name</span>
+                            </NavLink>
+                        </li>
+                        <li>
+                            <form action="Account/Logout" method="post">
+                                <AntiforgeryToken />
+                                <input type="hidden" name="ReturnUrl" value="@currentUrl" />
+                                <button type="submit" class="list-item medium">
+                                    <BitIcon IconName="@Icons.ItClose" />
+                                    <span>Disconnetti</span>
+                                </button>
+                            </form>
+                        </li>
+                    </Authorized>
+                    <NotAuthorized>
+                        <li>
+                            <NavLink class="list-item medium" href="Account/Register">
+                                <BitIcon IconName="@Icons.ItUser" />
+                                <span>Registrati</span>
+                            </NavLink>
+                        </li>
+                        <li>
+                            <NavLink class="list-item medium" href="Account/Login">
+                                <BitIcon IconName="@Icons.ItSettings" />
+                                <span>Accedi</span>
+                            </NavLink>
+                        </li>
+                    </NotAuthorized>
+                </AuthorizeView>
+            </ul>
+        </div>
+    </div>
 
-    <NavLink class="sidebar-nav-link" href="modulistica">
-        <BitIcon IconName="@Icons.ItNote" />
-        <span>Modulistica</span>
-    </NavLink>
-
-    <NavLink class="sidebar-nav-link" href="comunicazioni">
-        <BitIcon IconName="@Icons.ItMail" />
-        <span>Comunicazioni</span>
-        <BitBadge Text="3" BackgroundColor="Color.Danger" Rounded="true" CssClass="ms-auto" />
-    </NavLink>
-
-    <NavLink class="sidebar-nav-link" href="sportello">
-        <BitIcon IconName="@Icons.ItCard" />
-        <span>Sportello Digitale</span>
-    </NavLink>
-
-    <div class="sidebar-divider"></div>
-    <div class="sidebar-section-title">Account</div>
-
-    <AuthorizeView>
-        <Authorized>
-            <NavLink class="sidebar-nav-link" href="Account/Manage">
-                <BitIcon IconName="@Icons.ItUser" />
-                <span>@context.User.Identity?.Name</span>
-            </NavLink>
-            <form action="Account/Logout" method="post">
-                <AntiforgeryToken />
-                <input type="hidden" name="ReturnUrl" value="@currentUrl" />
-                <button type="submit" class="sidebar-nav-link">
-                    <BitIcon IconName="@Icons.ItClose" />
-                    <span>Disconnetti</span>
-                </button>
-            </form>
-        </Authorized>
-        <NotAuthorized>
-            <NavLink class="sidebar-nav-link" href="Account/Register">
-                <BitIcon IconName="@Icons.ItUser" />
-                <span>Registrati</span>
-            </NavLink>
-            <NavLink class="sidebar-nav-link" href="Account/Login">
-                <BitIcon IconName="@Icons.ItSettings" />
-                <span>Accedi</span>
-            </NavLink>
-        </NotAuthorized>
-    </AuthorizeView>
 </div>
 
 @code {

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor.css
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor.css
@@ -1,15 +1,59 @@
-.navbar-toggler {
-    appearance: none;
-    cursor: pointer;
-    width: 3.5rem;
-    height: 2.5rem;
-    color: white;
-    position: absolute;
-    top: 0.5rem;
-    right: 1rem;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.75rem rgba(255, 255, 255, 0.1);
+/* =========================================
+   Sidebar navigation
+   ========================================= */
+.sidebar-nav {
+    padding: 1.25rem 0;
 }
+
+.sidebar-section-title {
+    padding: 0.5rem 1.25rem 0.3rem;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #9e9e9e;
+}
+
+.sidebar-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.6rem 1.25rem;
+    color: #404040;
+    text-decoration: none;
+    font-size: 0.88rem;
+    font-weight: 500;
+    transition: background-color 0.15s ease, color 0.15s ease, border-left-color 0.15s ease;
+    border-left: 3px solid transparent;
+    cursor: pointer;
+    background: none;
+    border-top: none;
+    border-right: none;
+    border-bottom: none;
+    width: 100%;
+    text-align: left;
+    line-height: 1.4;
+}
+
+    .sidebar-nav-link:hover {
+        background-color: #eaf1fb;
+        color: #06c;
+        border-left-color: rgba(0, 102, 204, 0.3);
+    }
+
+    .sidebar-nav-link.active {
+        background-color: #eaf1fb;
+        color: #06c;
+        font-weight: 600;
+        border-left-color: #06c;
+    }
+
+.sidebar-divider {
+    height: 1px;
+    background-color: #e8e8e8;
+    margin: 0.75rem 1rem;
+}
+
 
 .navbar-toggler:checked {
     background-color: rgba(255, 255, 255, 0.5);

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor.css
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Layout/NavMenu.razor.css
@@ -1,62 +1,20 @@
 /* =========================================
-   Sidebar navigation
+   Sidebar — Bootstrap Italia overrides
    ========================================= */
-.sidebar-nav {
-    padding: 1.25rem 0;
+
+/* Il sidebar-wrapper deve riempire il contenitore laterale */
+.sidebar-wrapper {
+    height: 100%;
+    overflow-y: auto;
 }
 
-.sidebar-section-title {
-    padding: 0.5rem 1.25rem 0.3rem;
-    font-size: 0.68rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #9e9e9e;
-}
-
-.sidebar-nav-link {
-    display: flex;
-    align-items: center;
-    gap: 0.7rem;
-    padding: 0.6rem 1.25rem;
-    color: #404040;
-    text-decoration: none;
-    font-size: 0.88rem;
-    font-weight: 500;
-    transition: background-color 0.15s ease, color 0.15s ease, border-left-color 0.15s ease;
-    border-left: 3px solid transparent;
-    cursor: pointer;
+/* Bottone logout: resetta lo stile <button> per sembrare un list-item */
+.list-item[type=submit] {
     background: none;
-    border-top: none;
-    border-right: none;
-    border-bottom: none;
+    border: none;
     width: 100%;
     text-align: left;
-    line-height: 1.4;
-}
-
-    .sidebar-nav-link:hover {
-        background-color: #eaf1fb;
-        color: #06c;
-        border-left-color: rgba(0, 102, 204, 0.3);
-    }
-
-    .sidebar-nav-link.active {
-        background-color: #eaf1fb;
-        color: #06c;
-        font-weight: 600;
-        border-left-color: #06c;
-    }
-
-.sidebar-divider {
-    height: 1px;
-    background-color: #e8e8e8;
-    margin: 0.75rem 1rem;
-}
-
-
-.navbar-toggler:checked {
-    background-color: rgba(255, 255, 255, 0.5);
+    cursor: pointer;
 }
 
 .top-row {

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Pages/Home.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Pages/Home.razor
@@ -1,7 +1,175 @@
 ﻿@page "/"
 
-<PageTitle>Home</PageTitle>
+<PageTitle>Dashboard — Comune di Bitopoli</PageTitle>
 
-<h1>Hello, world!</h1>
+<BitBreadcrumb Items="@breadcrumbItems" />
 
-Welcome to your new app.
+<div class="mt-3 mb-4">
+    <h1 class="h3 fw-bold mb-1">Benvenuto nel Portale Digitale</h1>
+    <p class="text-muted mb-0">
+        Accedi ai servizi del Comune di Bitopoli, gestisci le tue pratiche e rimani
+        informato sulle comunicazioni istituzionali.
+    </p>
+</div>
+
+<!-- Stats row -->
+<div class="row g-3 mb-4">
+    <div class="col-12 col-sm-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true" BorderTopColor="Color.Primary">
+            <CardBody>
+                <CardText>
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="stat-icon bg-primary-subtle rounded-3 p-3">
+                            <BitIcon IconName="@Icons.ItFolder" Size="IconSize.Large" Color="IconColor.Primary" />
+                        </div>
+                        <div>
+                            <div class="display-6 fw-bold text-primary lh-1">42</div>
+                            <div class="text-muted small mt-1">Pratiche in gestione</div>
+                        </div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-sm-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true" BorderTopColor="Color.Success">
+            <CardBody>
+                <CardText>
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="stat-icon bg-success-subtle rounded-3 p-3">
+                            <BitIcon IconName="@Icons.ItCheckCircle" Size="IconSize.Large" Color="IconColor.Success" />
+                        </div>
+                        <div>
+                            <div class="display-6 fw-bold text-success lh-1">128</div>
+                            <div class="text-muted small mt-1">Documenti disponibili</div>
+                        </div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-sm-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true" BorderTopColor="Color.Warning">
+            <CardBody>
+                <CardText>
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="stat-icon bg-warning-subtle rounded-3 p-3">
+                            <BitIcon IconName="@Icons.ItClock" Size="IconSize.Large" Color="IconColor.Warning" />
+                        </div>
+                        <div>
+                            <div class="display-6 fw-bold text-warning lh-1">7</div>
+                            <div class="text-muted small mt-1">In attesa di risposta</div>
+                        </div>
+                    </div>
+                </CardText>
+            </CardBody>
+        </BitCard>
+    </div>
+</div>
+
+<!-- Accessi rapidi -->
+<h2 class="h5 fw-bold mb-3">Accessi Rapidi</h2>
+<div class="row g-3 mb-4">
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardTitle>Anagrafe</CardTitle>
+                <CardText>
+                    <p class="text-muted small">
+                        Certificati di residenza, stato di famiglia e carta d'identità elettronica.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">
+                        Accedi al servizio
+                    </BitButton>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardTitle>Tributi</CardTitle>
+                <CardText>
+                    <p class="text-muted small">
+                        IMU, TARI, pagamenti e dichiarazioni fiscali comunali online.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">
+                        Accedi al servizio
+                    </BitButton>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardTitle>Edilizia & Urbanistica</CardTitle>
+                <CardText>
+                    <p class="text-muted small">
+                        Permessi di costruire, CILA, SCIA e pratiche urbanistiche.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">
+                        Accedi al servizio
+                    </BitButton>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <CardTitle>SUAP</CardTitle>
+                <CardText>
+                    <p class="text-muted small">
+                        Sportello unico attività produttive, avvio e modifica d'impresa.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">
+                        Accedi al servizio
+                    </BitButton>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+</div>
+
+<!-- Comunicazioni recenti -->
+<div class="d-flex align-items-center justify-content-between mb-3">
+    <h2 class="h5 fw-bold mb-0">Comunicazioni recenti</h2>
+    <a href="/comunicazioni" class="small text-primary">Vedi tutte →</a>
+</div>
+<div class="d-flex flex-column gap-2">
+    <BitAlert Type="AlertType.Warning" Title="Interruzione servizi idrici">
+        <p class="mb-0">
+            Il 20 marzo 2026 dalle 08:00 alle 14:00 si effettueranno lavori alla rete idrica
+            in Via Roma e Corso Italia.
+        </p>
+    </BitAlert>
+    <BitAlert Type="AlertType.Info" Title="Rinnovo documenti d'identità">
+        <p class="mb-0">
+            È possibile prenotare il rinnovo della carta d'identità elettronica tramite il portale
+            o allo sportello previo appuntamento.
+        </p>
+    </BitAlert>
+    <BitAlert Type="AlertType.Success" Title="Nuovo servizio online disponibile">
+        <p class="mb-0">
+            Dal 15 marzo 2026 è disponibile l'autocertificazione digitale per le pratiche SUAP.
+            <a href="/servizi" class="alert-link">Scopri di più</a>.
+        </p>
+    </BitAlert>
+</div>
+
+@code {
+    private IReadOnlyList<BitBreadcrumbItem> breadcrumbItems = new List<BitBreadcrumbItem>
+    {
+        new BitBreadcrumbItem { Text = "Home", Link = "/" }
+    };
+}
+

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Pages/Servizi.razor
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/Components/Pages/Servizi.razor
@@ -1,0 +1,319 @@
+@page "/servizi"
+
+<PageTitle>Servizi — Comune di Bitopoli</PageTitle>
+
+<BitBreadcrumb Items="@breadcrumbItems" />
+
+<div class="mt-3 mb-4">
+    <h1 class="h3 fw-bold mb-1">Catalogo dei Servizi</h1>
+    <p class="text-muted mb-0">
+        Tutti i servizi comunali disponibili online. Seleziona la categoria per trovare
+        rapidamente ciò di cui hai bisogno.
+    </p>
+</div>
+
+<!-- Filtri categoria -->
+<div class="d-flex flex-wrap gap-2 mb-4">
+    <BitBadge Text="Tutti" BackgroundColor="Color.Primary" Rounded="true" />
+    <BitBadge Text="Anagrafe" BackgroundColor="Color.Secondary" Rounded="true" />
+    <BitBadge Text="Tributi" BackgroundColor="Color.Secondary" Rounded="true" />
+    <BitBadge Text="Edilizia" BackgroundColor="Color.Secondary" Rounded="true" />
+    <BitBadge Text="Ambiente" BackgroundColor="Color.Secondary" Rounded="true" />
+    <BitBadge Text="Sociale" BackgroundColor="Color.Secondary" Rounded="true" />
+</div>
+
+<!-- Anagrafe -->
+<h2 class="h5 fw-semibold mb-3 d-flex align-items-center gap-2">
+    <BitIcon IconName="@Icons.ItUser" Color="IconColor.Primary" />
+    Anagrafe e Stato Civile
+</h2>
+<div class="row g-3 mb-5">
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Certificato di Residenza</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Rilascio del certificato di residenza anagrafica. Disponibile anche in
+                        formato digitale con firma elettronica.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Richiedi</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Info</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Stato di Famiglia</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Certificato attestante la composizione del nucleo familiare anagrafico
+                        alla data di rilascio.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Richiedi</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Info</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Carta d'Identità Elettronica</CardTitle>
+                    <BitBadge Text="Sportello" BackgroundColor="Color.Warning" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Rinnovo e primo rilascio della CIE. Prenotazione appuntamento disponibile
+                        online, ritiro fisico allo sportello.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Prenota</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Info</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Cambio di Residenza</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Dichiarazione di cambio di residenza nel Comune o trasferimento
+                        da altro Comune.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Richiedi</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Info</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Atto di Nascita</CardTitle>
+                    <BitBadge Text="Sportello" BackgroundColor="Color.Warning" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Copia integrale o estratto dell'atto di nascita per uso
+                        dichiarativo o internazionale.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Prenota</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Info</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Certificato Elettorale</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Iscrizione nelle liste elettorali, certificato di iscrizione e
+                        tessera elettorale.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Richiedi</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Info</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+</div>
+
+<!-- Tributi -->
+<h2 class="h5 fw-semibold mb-3 d-flex align-items-center gap-2">
+    <BitIcon IconName="@Icons.ItCard" Color="IconColor.Primary" />
+    Tributi e Pagamenti
+</h2>
+<div class="row g-3 mb-5">
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>IMU</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Calcolo e pagamento dell'Imposta Municipale Propria. Simulatore,
+                        aliquote e scadenze.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Calcola e Paga</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Aliquote</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>TARI</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Tassa sui rifiuti: dichiarazione, variazione utenze, pagamento rate
+                        e riduzioni tariffarie.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Gestisci</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Tariffe</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Multa e Sanzioni</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Pagamento verbali di violazione del Codice della Strada e altre
+                        sanzioni amministrative.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Paga Ora</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Ricerca</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+</div>
+
+<!-- Edilizia -->
+<h2 class="h5 fw-semibold mb-3 d-flex align-items-center gap-2">
+    <BitIcon IconName="@Icons.ItMapMarker" Color="IconColor.Primary" />
+    Edilizia e Territorio
+</h2>
+<div class="row g-3 mb-4">
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>CILA / SCIA</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Comunicazione di inizio lavori e Segnalazione Certificata di Inizio Attività
+                        edilizia.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Presenta</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Guida</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Permesso di Costruire</CardTitle>
+                    <BitBadge Text="Istruttoria" BackgroundColor="Color.Danger" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Domanda di permesso per interventi di nuova costruzione, ristrutturazione
+                        o ampliamento significativi.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Richiedi</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Normativa</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+        <BitCard Bordered="true" Shadow="CardShadow.Small" FullHeight="true">
+            <CardBody>
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <CardTitle>Visura Catastale</CardTitle>
+                    <BitBadge Text="Online" BackgroundColor="Color.Success" Rounded="true" />
+                </div>
+                <CardText>
+                    <p class="text-muted small">
+                        Consultazione delle mappe catastali, planimetrie e dati degli immobili
+                        presenti nel territorio comunale.
+                    </p>
+                </CardText>
+                <CardFooter>
+                    <div class="d-flex gap-2">
+                        <BitButton Color="Color.Primary" Size="Size.Small">Consulta</BitButton>
+                        <BitButton Color="Color.Primary" Variant="Variant.Outline" Size="Size.Small">Info</BitButton>
+                    </div>
+                </CardFooter>
+            </CardBody>
+        </BitCard>
+    </div>
+</div>
+
+@code {
+    private IReadOnlyList<BitBreadcrumbItem> breadcrumbItems = new List<BitBreadcrumbItem>
+    {
+        new BitBreadcrumbItem { Text = "Home", Link = "/" },
+        new BitBreadcrumbItem { Text = "Servizi" }
+    };
+}

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/wwwroot/app.css
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/wwwroot/app.css
@@ -1,5 +1,5 @@
 html, body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: 'Titillium Web', sans-serif;
 }
 
 a, .btn-link {

--- a/samples/BitBlazor.Sample/BitBlazor.Sample/wwwroot/app.css
+++ b/samples/BitBlazor.Sample/BitBlazor.Sample/wwwroot/app.css
@@ -50,6 +50,16 @@ h1:focus {
     border-color: #929292;
 }
 
+/*
+ * Bootstrap Italia sets .form-group { margin-top: 0 } but its labels are
+ * absolutely positioned and shift upward via transform: translateY(-85%),
+ * making them visually overlap the element above. Adding margin-top gives
+ * the label room to float without covering the preceding element.
+ */
+.form-group {
+    margin-top: 1.5rem;
+}
+
 .form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
     color: var(--bs-secondary-color);
     text-align: end;

--- a/src/BitBlazor/Components/Modal/BitModal.razor
+++ b/src/BitBlazor/Components/Modal/BitModal.razor
@@ -1,0 +1,62 @@
+@namespace BitBlazor.Components
+
+@inherits BitComponentBase
+
+@if (IsVisible)
+{
+    @if (Backdrop != ModalBackdrop.None)
+    {
+        <div class="modal-backdrop fade show" @onclick="HandleBackdropClickAsync"></div>
+    }
+
+    <div class="@ComputeModalCssClasses()"
+         tabindex="-1"
+         role="dialog"
+         aria-modal="true"
+         aria-label="@(string.IsNullOrWhiteSpace(Title) ? AriaLabel : null)"
+         aria-labelledby="@(!string.IsNullOrWhiteSpace(Title) ? _titleId : null)"
+         aria-describedby="@AriaDescribedById"
+         style="display:block;"
+         @attributes="AdditionalAttributes">
+        <div class="@ComputeDialogCssClasses()" role="document" @onclick:stopPropagation="true">
+            <div class="modal-content">
+
+                @if (HasHeader)
+                {
+                    <div class="modal-header">
+                        @if (HeaderContent is not null)
+                        {
+                            @HeaderContent
+                        }
+                        else
+                        {
+                            @if (!string.IsNullOrWhiteSpace(Title))
+                            {
+                                <h2 class="modal-title h5" id="@_titleId">@Title</h2>
+                            }
+                        }
+
+                        @if (ShowCloseButton)
+                        {
+                            <button type="button" class="btn-close" aria-label="@CloseButtonAriaLabel" @onclick="CloseAsync">
+                                <BitIcon IconName="@Icons.ItClose" />
+                            </button>
+                        }
+                    </div>
+                }
+
+                <div class="modal-body">
+                    @BodyContent
+                </div>
+
+                @if (FooterContent is not null)
+                {
+                    <div class="@ComputeFooterCssClasses()">
+                        @FooterContent
+                    </div>
+                }
+
+            </div>
+        </div>
+    </div>
+}

--- a/src/BitBlazor/Components/Modal/BitModal.razor.cs
+++ b/src/BitBlazor/Components/Modal/BitModal.razor.cs
@@ -1,0 +1,255 @@
+using BitBlazor.Core;
+using BitBlazor.Utilities;
+using Microsoft.AspNetCore.Components;
+
+namespace BitBlazor.Components;
+
+/// <summary>
+/// Represents a modal dialog component following Bootstrap Italia styles and accessibility guidelines.
+/// </summary>
+/// <remarks>
+/// The modal visibility is controlled entirely via Blazor state using <see cref="IsVisible"/> /
+/// <see cref="IsVisibleChanged"/> — no JavaScript interop is required to show or hide it.
+/// </remarks>
+public partial class BitModal : BitComponentBase
+{
+    private string _autoId = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether the modal is currently visible.
+    /// </summary>
+    [Parameter]
+    public bool IsVisible { get; set; }
+
+    /// <summary>
+    /// Callback invoked when the modal visibility changes, enabling two-way binding via <c>@bind-IsVisible</c>.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> IsVisibleChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets the main body content of the modal.
+    /// </summary>
+    [Parameter]
+    [EditorRequired]
+    public RenderFragment BodyContent { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets an optional title displayed in the modal header as an <c>h2</c> element.
+    /// </summary>
+    /// <remarks>
+    /// When set, the modal automatically receives an <c>aria-labelledby</c> attribute pointing to the title element.
+    /// When <see langword="null"/>, use <see cref="AriaLabel"/> for accessibility.
+    /// </remarks>
+    [Parameter]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for the <c>id</c> attribute of the title <c>h2</c> element.
+    /// When <see langword="null"/>, an auto-generated ID based on the modal's own ID is used.
+    /// </summary>
+    [Parameter]
+    public string? TitleId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <c>aria-label</c> attribute for the modal.
+    /// Use this when <see cref="Title"/> is not set to ensure accessibility for screen readers.
+    /// </summary>
+    [Parameter]
+    public string? AriaLabel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of the <c>aria-describedby</c> attribute on the modal element,
+    /// pointing to the element ID that provides a description of the dialog.
+    /// </summary>
+    [Parameter]
+    public string? AriaDescribedById { get; set; }
+
+    /// <summary>
+    /// Gets or sets a fully custom header render fragment that replaces the default title/close-button header.
+    /// When set, <see cref="Title"/> is ignored but <see cref="ShowCloseButton"/> still applies.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? HeaderContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the footer content of the modal.
+    /// When <see langword="null"/>, no footer element is rendered.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? FooterContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether a close button (<c>×</c>) is shown in the modal header. Defaults to <c>true</c>.
+    /// </summary>
+    [Parameter]
+    public bool ShowCloseButton { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the <c>aria-label</c> value for the close button, used by screen readers.
+    /// Defaults to <c>"Chiudi"</c>.
+    /// </summary>
+    [Parameter]
+    public string CloseButtonAriaLabel { get; set; } = "Chiudi";
+
+    /// <summary>
+    /// Gets or sets the size variant of the modal. Defaults to <see cref="ModalSize.Default"/>.
+    /// </summary>
+    [Parameter]
+    public ModalSize Size { get; set; } = ModalSize.Default;
+
+    /// <summary>
+    /// Gets or sets the positioning variant of the modal. Defaults to <see cref="ModalPosition.Default"/>.
+    /// </summary>
+    [Parameter]
+    public ModalPosition Position { get; set; } = ModalPosition.Default;
+
+    /// <summary>
+    /// Gets or sets the visual type variant of the modal. Defaults to <see cref="ModalType.Default"/>.
+    /// </summary>
+    [Parameter]
+    public ModalType Type { get; set; } = ModalType.Default;
+
+    /// <summary>
+    /// Gets or sets the backdrop behaviour. Defaults to <see cref="ModalBackdrop.Default"/>.
+    /// </summary>
+    [Parameter]
+    public ModalBackdrop Backdrop { get; set; } = ModalBackdrop.Default;
+
+    /// <summary>
+    /// Gets or sets whether the modal body content should scroll internally,
+    /// keeping the header and footer always visible.
+    /// Applies the <c>it-dialog-scrollable</c> class to the modal element.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    [Parameter]
+    public bool ScrollableContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the modal footer renders with a top shadow (<c>modal-footer-shadow</c>).
+    /// Useful for long scrollable content. Defaults to <c>false</c>.
+    /// </summary>
+    [Parameter]
+    public bool FooterShadow { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the modal uses a fade animation when appearing/disappearing.
+    /// Defaults to <c>true</c>.
+    /// </summary>
+    [Parameter]
+    public bool Fade { get; set; } = true;
+
+    /// <summary>
+    /// Callback invoked just before the modal is closed (before <see cref="IsVisible"/> is set to <c>false</c>).
+    /// </summary>
+    [Parameter]
+    public EventCallback OnClose { get; set; }
+
+    /// <summary>Gets the effective element ID, using the auto-generated fallback when <see cref="BitComponentBase.Id"/> is not set.</summary>
+    private string _effectiveId => string.IsNullOrWhiteSpace(Id) ? _autoId : Id!;
+
+    /// <summary>Gets the ID used for the title <c>h2</c> element and <c>aria-labelledby</c>.</summary>
+    private string _titleId => string.IsNullOrWhiteSpace(TitleId) ? $"{_effectiveId}-title" : TitleId!;
+
+    /// <summary>
+    /// Returns <c>true</c> when a header section should be rendered (title, custom header content or close button).
+    /// </summary>
+    private bool HasHeader => !string.IsNullOrWhiteSpace(Title) || HeaderContent is not null || ShowCloseButton;
+
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        _autoId = $"modal-{Guid.NewGuid():N}"[..14];
+        base.OnInitialized();
+    }
+
+    /// <inheritdoc/>
+    protected override void SetElementId()
+    {
+        AdditionalAttributes["id"] = _effectiveId;
+    }
+
+    private string ComputeModalCssClasses()
+    {
+        var builder = new CssClassBuilder("modal");
+
+        if (Fade)
+        {
+            builder.Add("fade");
+        }
+
+        if (IsVisible)
+        {
+            builder.Add("show");
+        }
+
+        var typeClass = Type switch
+        {
+            ModalType.Alert => "alert-modal",
+            ModalType.LinkList => "it-dialog-link-list",
+            ModalType.Popconfirm => "popconfirm-modal",
+            _ => string.Empty,
+        };
+        builder.Add(typeClass);
+
+        if (ScrollableContent || Position == ModalPosition.Left || Position == ModalPosition.Right)
+        {
+            builder.Add("it-dialog-scrollable");
+        }
+
+        AddCustomCssClass(builder);
+
+        return builder.Build();
+    }
+
+    private string ComputeDialogCssClasses()
+    {
+        var builder = new CssClassBuilder("modal-dialog");
+
+        var sizeClass = Size switch
+        {
+            ModalSize.Small => "modal-sm",
+            ModalSize.Large => "modal-lg",
+            ModalSize.ExtraLarge => "modal-xl",
+            _ => string.Empty,
+        };
+        builder.Add(sizeClass);
+
+        var positionClass = Position switch
+        {
+            ModalPosition.Centered => "modal-dialog-centered",
+            ModalPosition.Left => "modal-dialog-left",
+            ModalPosition.Right => "modal-dialog-right",
+            _ => string.Empty,
+        };
+        builder.Add(positionClass);
+
+        return builder.Build();
+    }
+
+    private string ComputeFooterCssClasses()
+    {
+        var builder = new CssClassBuilder("modal-footer");
+
+        if (FooterShadow)
+        {
+            builder.Add("modal-footer-shadow");
+        }
+
+        return builder.Build();
+    }
+
+    private async Task CloseAsync()
+    {
+        await OnClose.InvokeAsync();
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private async Task HandleBackdropClickAsync()
+    {
+        if (Backdrop != ModalBackdrop.Static)
+        {
+            await CloseAsync();
+        }
+    }
+}

--- a/src/BitBlazor/Components/Modal/ModalBackdrop.cs
+++ b/src/BitBlazor/Components/Modal/ModalBackdrop.cs
@@ -1,0 +1,22 @@
+namespace BitBlazor.Components;
+
+/// <summary>
+/// Defines the backdrop behaviour for the <see cref="BitModal"/> component.
+/// </summary>
+public enum ModalBackdrop
+{
+    /// <summary>
+    /// A backdrop is shown and clicking it closes the modal.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// A backdrop is shown but clicking it does <b>not</b> close the modal.
+    /// </summary>
+    Static,
+
+    /// <summary>
+    /// No backdrop is shown.
+    /// </summary>
+    None,
+}

--- a/src/BitBlazor/Components/Modal/ModalPosition.cs
+++ b/src/BitBlazor/Components/Modal/ModalPosition.cs
@@ -1,0 +1,29 @@
+namespace BitBlazor.Components;
+
+/// <summary>
+/// Defines the positioning variants available for the <see cref="BitModal"/> component.
+/// </summary>
+public enum ModalPosition
+{
+    /// <summary>
+    /// Default positioning (top-center).
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Vertically centered modal. Applies <c>modal-dialog-centered</c> to the dialog element.
+    /// </summary>
+    Centered,
+
+    /// <summary>
+    /// Left-aligned, full-height modal. Applies <c>it-dialog-scrollable</c> to the modal element
+    /// and <c>modal-dialog-left</c> to the dialog element.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// Right-aligned, full-height modal. Applies <c>it-dialog-scrollable</c> to the modal element
+    /// and <c>modal-dialog-right</c> to the dialog element.
+    /// </summary>
+    Right,
+}

--- a/src/BitBlazor/Components/Modal/ModalSize.cs
+++ b/src/BitBlazor/Components/Modal/ModalSize.cs
@@ -1,0 +1,27 @@
+namespace BitBlazor.Components;
+
+/// <summary>
+/// Defines the size variants available for the <see cref="BitModal"/> component.
+/// </summary>
+public enum ModalSize
+{
+    /// <summary>
+    /// Default size (no extra size class applied).
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Small modal. Applies the <c>modal-sm</c> class to the dialog element.
+    /// </summary>
+    Small,
+
+    /// <summary>
+    /// Large modal. Applies the <c>modal-lg</c> class to the dialog element.
+    /// </summary>
+    Large,
+
+    /// <summary>
+    /// Extra-large modal. Applies the <c>modal-xl</c> class to the dialog element.
+    /// </summary>
+    ExtraLarge,
+}

--- a/src/BitBlazor/Components/Modal/ModalType.cs
+++ b/src/BitBlazor/Components/Modal/ModalType.cs
@@ -1,0 +1,27 @@
+namespace BitBlazor.Components;
+
+/// <summary>
+/// Defines the visual type variants available for the <see cref="BitModal"/> component.
+/// </summary>
+public enum ModalType
+{
+    /// <summary>
+    /// Default modal with no additional type class.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Alert modal. Applies the <c>alert-modal</c> class, used alongside an icon in the header.
+    /// </summary>
+    Alert,
+
+    /// <summary>
+    /// Link list modal. Applies the <c>it-dialog-link-list</c> class, optimised for rendering navigation link lists.
+    /// </summary>
+    LinkList,
+
+    /// <summary>
+    /// Popconfirm modal. Applies the <c>popconfirm-modal</c> class for compact confirmation dialogs.
+    /// </summary>
+    Popconfirm,
+}

--- a/src/BitBlazor/wwwroot/css/fonts.css
+++ b/src/BitBlazor/wwwroot/css/fonts.css
@@ -1,0 +1,268 @@
+/*
+ * Bootstrap Italia — default fonts
+ * Include this file in your app to use the official BootstrapItalia typography.
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="_content/BitBlazor/css/fonts.css" />
+ *
+ * Font families declared here:
+ *   - Titillium Web  (sans-serif — primary UI font)
+ *   - Lora           (serif — display/reading)
+ *   - Roboto Mono    (monospace — code)
+ */
+
+/* ============================================================
+   Titillium Web — 300 (Light)
+   ============================================================ */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: normal;
+    font-weight: 300;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.svg#TitilliumWeb') format('svg');
+}
+
+/* Titillium Web — 300 Italic */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: italic;
+    font-weight: 300;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.svg#TitilliumWeb') format('svg');
+}
+
+/* ============================================================
+   Titillium Web — 400 (Regular)
+   ============================================================ */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.svg#TitilliumWeb') format('svg');
+}
+
+/* Titillium Web — 400 Italic */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: italic;
+    font-weight: 400;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.svg#TitilliumWeb') format('svg');
+}
+
+/* ============================================================
+   Titillium Web — 600 (SemiBold)
+   ============================================================ */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.svg#TitilliumWeb') format('svg');
+}
+
+/* Titillium Web — 600 Italic */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: italic;
+    font-weight: 600;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.svg#TitilliumWeb') format('svg');
+}
+
+/* ============================================================
+   Titillium Web — 700 (Bold)
+   ============================================================ */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.svg#TitilliumWeb') format('svg');
+}
+
+/* Titillium Web — 700 Italic */
+@font-face {
+    font-family: 'Titillium Web';
+    font-style: italic;
+    font-weight: 700;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.svg#TitilliumWeb') format('svg');
+}
+
+/* ============================================================
+   Lora — 400 (Regular)
+   ============================================================ */
+@font-face {
+    font-family: 'Lora';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.svg#Lora') format('svg');
+}
+
+/* Lora — 400 Italic */
+@font-face {
+    font-family: 'Lora';
+    font-style: italic;
+    font-weight: 400;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.svg#Lora') format('svg');
+}
+
+/* ============================================================
+   Lora — 700 (Bold)
+   ============================================================ */
+@font-face {
+    font-family: 'Lora';
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.svg#Lora') format('svg');
+}
+
+/* Lora — 700 Italic */
+@font-face {
+    font-family: 'Lora';
+    font-style: italic;
+    font-weight: 700;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.svg#Lora') format('svg');
+}
+
+/* ============================================================
+   Roboto Mono — 400 (Regular)
+   ============================================================ */
+@font-face {
+    font-family: 'Roboto Mono';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.svg#RobotoMono') format('svg');
+}
+
+/* Roboto Mono — 400 Italic */
+@font-face {
+    font-family: 'Roboto Mono';
+    font-style: italic;
+    font-weight: 400;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.svg#RobotoMono') format('svg');
+}
+
+/* ============================================================
+   Roboto Mono — 700 (Bold)
+   ============================================================ */
+@font-face {
+    font-family: 'Roboto Mono';
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.svg#RobotoMono') format('svg');
+}
+
+/* Roboto Mono — 700 Italic */
+@font-face {
+    font-family: 'Roboto Mono';
+    font-style: italic;
+    font-weight: 700;
+    font-display: swap;
+    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.eot');
+    src: local(''),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.woff2') format('woff2'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.woff') format('woff'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.ttf') format('truetype'),
+         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.svg#RobotoMono') format('svg');
+}

--- a/src/BitBlazor/wwwroot/css/fonts.css
+++ b/src/BitBlazor/wwwroot/css/fonts.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Bootstrap Italia — default fonts
  * Include this file in your app to use the official BootstrapItalia typography.
  *
@@ -66,13 +66,13 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-italic.svg#TitilliumWeb') format('svg');
 }
 
 /* ============================================================
@@ -83,13 +83,13 @@
     font-style: normal;
     font-weight: 600;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600.svg#TitilliumWeb') format('svg');
 }
 
 /* Titillium Web — 600 Italic */
@@ -98,13 +98,13 @@
     font-style: italic;
     font-weight: 600;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-600italic.svg#TitilliumWeb') format('svg');
 }
 
 /* ============================================================
@@ -115,13 +115,13 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700.svg#TitilliumWeb') format('svg');
 }
 
 /* Titillium Web — 700 Italic */
@@ -130,13 +130,13 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-700italic.svg#TitilliumWeb') format('svg');
 }
 
 /* ============================================================
@@ -147,13 +147,13 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.eot');
+    src: url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.svg#Lora') format('svg');
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-regular.svg#Lora') format('svg');
 }
 
 /* Lora — 400 Italic */
@@ -162,13 +162,13 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.eot');
+    src: url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.svg#Lora') format('svg');
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-italic.svg#Lora') format('svg');
 }
 
 /* ============================================================
@@ -179,13 +179,13 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.eot');
+    src: url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.svg#Lora') format('svg');
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700.svg#Lora') format('svg');
 }
 
 /* Lora — 700 Italic */
@@ -194,13 +194,13 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.eot');
+    src: url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.svg#Lora') format('svg');
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Lora/lora-v20-latin-ext_latin-700italic.svg#Lora') format('svg');
 }
 
 /* ============================================================
@@ -211,13 +211,13 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.eot');
+    src: url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.svg#RobotoMono') format('svg');
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-regular.svg#RobotoMono') format('svg');
 }
 
 /* Roboto Mono — 400 Italic */
@@ -226,13 +226,13 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.eot');
+    src: url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.svg#RobotoMono') format('svg');
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-italic.svg#RobotoMono') format('svg');
 }
 
 /* ============================================================
@@ -243,13 +243,13 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.eot');
+    src: url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.svg#RobotoMono') format('svg');
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700.svg#RobotoMono') format('svg');
 }
 
 /* Roboto Mono — 700 Italic */
@@ -258,11 +258,11 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.eot');
+    src: url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.svg#RobotoMono') format('svg');
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Roboto_Mono/roboto-mono-v13-latin-ext_latin-700italic.svg#RobotoMono') format('svg');
 }

--- a/src/BitBlazor/wwwroot/css/fonts.css
+++ b/src/BitBlazor/wwwroot/css/fonts.css
@@ -19,13 +19,13 @@
     font-style: normal;
     font-weight: 300;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300.svg#TitilliumWeb') format('svg');
 }
 
 /* Titillium Web — 300 Italic */
@@ -34,13 +34,13 @@
     font-style: italic;
     font-weight: 300;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-300italic.svg#TitilliumWeb') format('svg');
 }
 
 /* ============================================================
@@ -51,13 +51,13 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.eot');
+    src: url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.eot');
     src: local(''),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.woff2') format('woff2'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.woff') format('woff'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.ttf') format('truetype'),
-         url('_content/BitBlazor/bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.svg#TitilliumWeb') format('svg');
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.woff2') format('woff2'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.woff') format('woff'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.ttf') format('truetype'),
+         url('../bootstrap-italia/fonts/Titillium_Web/titillium-web-v10-latin-ext_latin-regular.svg#TitilliumWeb') format('svg');
 }
 
 /* Titillium Web — 400 Italic */

--- a/stories/BitBlazor.Stories/Components/Pages/IFramePage.razor
+++ b/stories/BitBlazor.Stories/Components/Pages/IFramePage.razor
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="css/blazor-ui.css" />
     <link rel="stylesheet" href="BitBlazor.Stories.styles.css" />
     <link rel="stylesheet" href="_content/BitBlazor/bootstrap-italia/css/bootstrap-italia.min.css" />
+    <link rel="stylesheet" href="_content/BitBlazor/css/fonts.css" />
     <HeadOutlet @rendermode="@InteractiveServer" />
 </head>
 

--- a/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
+++ b/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
@@ -3,22 +3,37 @@
 @using BitBlazor.Components
 
 <Stories TComponent="BitModal">
+    <ArgType For="_ => _.Title" />
     <ArgType For="_ => _.Size" Control="ControlType.Select" DefaultValue="ModalSize.Default" />
     <ArgType For="_ => _.Position" Control="ControlType.Select" DefaultValue="ModalPosition.Default" />
     <ArgType For="_ => _.Type" Control="ControlType.Select" DefaultValue="ModalType.Default" />
     <ArgType For="_ => _.Backdrop" Control="ControlType.Select" DefaultValue="ModalBackdrop.Default" />
+    <ArgType For="_ => _.ShowCloseButton" />
+    <ArgType For="_ => _.ScrollableContent" />
+    <ArgType For="_ => _.FooterShadow" />
+    <ArgType For="_ => _.Fade" />
 
     <Story Name="Default">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Intestazione modale")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.DefaultVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.DefaultVisible"
+                          @attributes="context.Args"
                           Id="story-modal-default"
-                          Title="Intestazione modale"
-                          AriaDescribedById="story-modal-default-desc"
-                          ShowCloseButton="false">
+                          AriaDescribedById="story-modal-default-desc">
                     <BodyContent>
                         <p id="story-modal-default-desc">Descrizione scopo della modale.</p>
                         <p>Font Titillium 16px. Leading 24px. omnis iste natus error sit voluptatem accusantium.</p>
@@ -35,14 +50,25 @@
     </Story>
 
     <Story Name="With close button">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Intestazione modale")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.CloseButtonVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.CloseButtonVisible"
+                          @attributes="context.Args"
                           Id="story-modal-closeable"
-                          Title="Intestazione modale"
                           CloseButtonAriaLabel="Chiudi questa finestra">
                     <BodyContent>
                         <p>La modale può essere chiusa facendo clic sul pulsante X nell'intestazione.</p>
@@ -59,15 +85,24 @@
     </Story>
 
     <Story Name="Sizes - Small">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale piccola")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Small" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.SizeSmallVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.SizeSmallVisible"
-                          Size="ModalSize.Small"
-                          Title="Modale piccola"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>Questo è un esempio di modale di dimensione ridotta.</p>
@@ -82,15 +117,24 @@
     </Story>
 
     <Story Name="Sizes - Large">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale grande")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Large" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.SizeLargeVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.SizeLargeVisible"
-                          Size="ModalSize.Large"
-                          Title="Modale grande"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>Questo è un esempio di modale di dimensione grande.</p>
@@ -105,15 +149,24 @@
     </Story>
 
     <Story Name="Sizes - Extra Large">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale molto grande")" />
+            <Arg For="_ => _.Size" Value="ModalSize.ExtraLarge" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.SizeXLVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.SizeXLVisible"
-                          Size="ModalSize.ExtraLarge"
-                          Title="Modale molto grande"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>Questo è un esempio di modale di dimensione molto grande.</p>
@@ -128,15 +181,24 @@
     </Story>
 
     <Story Name="Position - Centered">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale centrata")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Centered" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.CenteredVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.CenteredVisible"
-                          Position="ModalPosition.Centered"
-                          Title="Modale centrata"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>La modale è centrata verticalmente nella viewport.</p>
@@ -151,15 +213,24 @@
     </Story>
 
     <Story Name="Position - Left">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale a sinistra")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Left" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.LeftVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.LeftVisible"
-                          Position="ModalPosition.Left"
-                          Title="Modale a sinistra"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>La modale si apre da sinistra e occupa tutta l'altezza disponibile.</p>
@@ -170,15 +241,24 @@
     </Story>
 
     <Story Name="Position - Right">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale a destra")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Right" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.RightVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.RightVisible"
-                          Position="ModalPosition.Right"
-                          Title="Modale a destra"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>La modale si apre da destra e occupa tutta l'altezza disponibile.</p>
@@ -189,15 +269,26 @@
     </Story>
 
     <Story Name="Type - Alert (with icon)">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@((string?)null)" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Alert" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="false" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.AlertVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.AlertVisible"
-                          Type="ModalType.Alert"
+                          @attributes="context.Args"
                           AriaLabel="Messaggio di notifica"
-                          ShowCloseButton="false">
+                          >
                     <HeaderContent>
                         <div class="d-flex align-items-center">
                             <BitIcon IconName="@Icons.ItWarningCircle" CssClass="me-2" />
@@ -217,15 +308,26 @@
     </Story>
 
     <Story Name="Type - Popconfirm (basic)">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@((string?)null)" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Popconfirm" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="false" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.PopconfirmBasicVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.PopconfirmBasicVisible"
-                          Type="ModalType.Popconfirm"
+                          @attributes="context.Args"
                           AriaLabel="Conferma azione"
-                          ShowCloseButton="false">
+                          >
                     <BodyContent>
                         <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
                     </BodyContent>
@@ -241,15 +343,24 @@
     </Story>
 
     <Story Name="Type - Popconfirm (with header)">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Intestazione Popconfirm")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Popconfirm" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="false" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.PopconfirmHeaderVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.PopconfirmHeaderVisible"
-                          Type="ModalType.Popconfirm"
-                          Title="Intestazione Popconfirm"
-                          ShowCloseButton="false">
+                          @attributes="context.Args">
                     <BodyContent>
                         <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
                     </BodyContent>
@@ -265,14 +376,26 @@
     </Story>
 
     <Story Name="No header">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@((string?)null)" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="false" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.NoHeaderVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.NoHeaderVisible"
+                          @attributes="context.Args"
                           AriaLabel="Finestra senza intestazione"
-                          ShowCloseButton="false">
+                          >
                     <BodyContent>
                         <p>Questa modale non ha intestazione. Usare <code>ShowCloseButton="false"</code> e non impostare <code>Title</code> o <code>HeaderContent</code>.</p>
                     </BodyContent>
@@ -286,17 +409,26 @@
     </Story>
 
     <Story Name="Scrollable content">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale con contenuto scorrevole")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="true" />
+            <Arg For="_ => _.FooterShadow" Value="true" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.ScrollableVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.ScrollableVisible"
-                          ScrollableContent="true"
-                          Title="Modale con contenuto scorrevole"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi"
-                          FooterShadow="true">
+                          >
                     <BodyContent>
                         <p>Testo molto lungo che causa lo scroll interno della modale.</p>
                         @for (int i = 1; i <= 15; i++)
@@ -316,15 +448,24 @@
     </Story>
 
     <Story Name="Backdrop - Static">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Backdrop statico")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Static" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="true" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.StaticBackdropVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.StaticBackdropVisible"
-                          Backdrop="ModalBackdrop.Static"
-                          Title="Backdrop statico"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>Con <code>Backdrop="ModalBackdrop.Static"</code> il clic sullo sfondo non chiude la modale.</p>
@@ -341,15 +482,24 @@
     </Story>
 
     <Story Name="No animation (fade disabled)">
+        <Arguments>
+            <Arg For="_ => _.Title" Value="@("Modale senza animazione")" />
+            <Arg For="_ => _.Size" Value="ModalSize.Default" />
+            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+            <Arg For="_ => _.Type" Value="ModalType.Default" />
+            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+            <Arg For="_ => _.ShowCloseButton" Value="true" />
+            <Arg For="_ => _.ScrollableContent" Value="false" />
+            <Arg For="_ => _.FooterShadow" Value="false" />
+            <Arg For="_ => _.Fade" Value="false" />
+        </Arguments>
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.NoFadeVisible = true">
                     Apri modale
                 </button>
                 <BitModal @bind-IsVisible="model.NoFadeVisible"
-                          Fade="false"
-                          Title="Modale senza animazione"
-                          ShowCloseButton="true"
+                          @attributes="context.Args"
                           CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>La classe <code>fade</code> non viene applicata, quindi non c'è animazione di dissolvenza.</p>

--- a/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
+++ b/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
@@ -15,7 +15,7 @@
 
     <Story Name="Default">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Intestazione modale")" />
+            <Arg For="_ => _.Title" Value="@("Modal header")" />
             <Arg For="_ => _.Size" Value="ModalSize.Default" />
             <Arg For="_ => _.Position" Value="ModalPosition.Default" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -28,21 +28,17 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.DefaultVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.DefaultVisible"
-                          @attributes="context.Args"
-                          Id="story-modal-default"
+                <BitModal @bind-IsVisible="model.DefaultVisible" @attributes="context.Args" Id="story-modal-default"
                           AriaDescribedById="story-modal-default-desc">
                     <BodyContent>
-                        <p id="story-modal-default-desc">Descrizione scopo della modale.</p>
+                        <p id="story-modal-default-desc">Description of the modal's purpose.</p>
                         <p>Font Titillium 16px. Leading 24px. omnis iste natus error sit voluptatem accusantium.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button"
-                                @onclick="() => model.DefaultVisible = false">Annulla</button>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.DefaultVisible = false">Azione 1</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button" @onclick="() => model.DefaultVisible = false">Cancel</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.DefaultVisible = false">Action 1</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -51,7 +47,7 @@
 
     <Story Name="With close button">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Intestazione modale")" />
+            <Arg For="_ => _.Title" Value="@("Modal header")" />
             <Arg For="_ => _.Size" Value="ModalSize.Default" />
             <Arg For="_ => _.Position" Value="ModalPosition.Default" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -64,20 +60,16 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.CloseButtonVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.CloseButtonVisible"
-                          @attributes="context.Args"
-                          Id="story-modal-closeable"
-                          CloseButtonAriaLabel="Chiudi questa finestra">
+                <BitModal @bind-IsVisible="model.CloseButtonVisible" @attributes="context.Args" Id="story-modal-closeable"
+                          CloseButtonAriaLabel="Close this window">
                     <BodyContent>
-                        <p>La modale può essere chiusa facendo clic sul pulsante X nell'intestazione.</p>
+                        <p>The modal can be closed by clicking the X button in the header.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button"
-                                @onclick="() => model.CloseButtonVisible = false">Annulla</button>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.CloseButtonVisible = false">Azione 1</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button" @onclick="() => model.CloseButtonVisible = false">Cancel</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.CloseButtonVisible = false">Action 1</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -86,7 +78,7 @@
 
     <Story Name="Sizes - Small">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale piccola")" />
+            <Arg For="_ => _.Title" Value="@("Small modal")" />
             <Arg For="_ => _.Size" Value="ModalSize.Small" />
             <Arg For="_ => _.Position" Value="ModalPosition.Default" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -99,17 +91,14 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.SizeSmallVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.SizeSmallVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
+                <BitModal @bind-IsVisible="model.SizeSmallVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
                     <BodyContent>
-                        <p>Questo è un esempio di modale di dimensione ridotta.</p>
+                        <p>This is an example of a small modal.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.SizeSmallVisible = false">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.SizeSmallVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -118,7 +107,7 @@
 
     <Story Name="Sizes - Large">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale grande")" />
+            <Arg For="_ => _.Title" Value="@("Large modal")" />
             <Arg For="_ => _.Size" Value="ModalSize.Large" />
             <Arg For="_ => _.Position" Value="ModalPosition.Default" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -131,17 +120,14 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.SizeLargeVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.SizeLargeVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
+                <BitModal @bind-IsVisible="model.SizeLargeVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
                     <BodyContent>
-                        <p>Questo è un esempio di modale di dimensione grande.</p>
+                        <p>This is an example of a large modal.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.SizeLargeVisible = false">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.SizeLargeVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -150,7 +136,7 @@
 
     <Story Name="Sizes - Extra Large">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale molto grande")" />
+            <Arg For="_ => _.Title" Value="@("Extra large modal")" />
             <Arg For="_ => _.Size" Value="ModalSize.ExtraLarge" />
             <Arg For="_ => _.Position" Value="ModalPosition.Default" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -163,17 +149,14 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.SizeXLVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.SizeXLVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
+                <BitModal @bind-IsVisible="model.SizeXLVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
                     <BodyContent>
-                        <p>Questo è un esempio di modale di dimensione molto grande.</p>
+                        <p>This is an example of an extra large modal.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.SizeXLVisible = false">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.SizeXLVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -182,7 +165,7 @@
 
     <Story Name="Position - Centered">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale centrata")" />
+            <Arg For="_ => _.Title" Value="@("Centered modal")" />
             <Arg For="_ => _.Size" Value="ModalSize.Default" />
             <Arg For="_ => _.Position" Value="ModalPosition.Centered" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -195,17 +178,14 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.CenteredVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.CenteredVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
+                <BitModal @bind-IsVisible="model.CenteredVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
                     <BodyContent>
-                        <p>La modale è centrata verticalmente nella viewport.</p>
+                        <p>The modal is vertically centered in the viewport.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.CenteredVisible = false">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.CenteredVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -214,7 +194,7 @@
 
     <Story Name="Position - Left">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale a sinistra")" />
+            <Arg For="_ => _.Title" Value="@("Left modal")" />
             <Arg For="_ => _.Size" Value="ModalSize.Default" />
             <Arg For="_ => _.Position" Value="ModalPosition.Left" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -227,13 +207,11 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.LeftVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.LeftVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
+                <BitModal @bind-IsVisible="model.LeftVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
                     <BodyContent>
-                        <p>La modale si apre da sinistra e occupa tutta l'altezza disponibile.</p>
+                        <p>The modal opens from the left and takes up the full available height.</p>
                     </BodyContent>
                 </BitModal>
             </div>
@@ -242,7 +220,7 @@
 
     <Story Name="Position - Right">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale a destra")" />
+            <Arg For="_ => _.Title" Value="@("Right modal")" />
             <Arg For="_ => _.Size" Value="ModalSize.Default" />
             <Arg For="_ => _.Position" Value="ModalPosition.Right" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -255,13 +233,11 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.RightVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.RightVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
+                <BitModal @bind-IsVisible="model.RightVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
                     <BodyContent>
-                        <p>La modale si apre da destra e occupa tutta l'altezza disponibile.</p>
+                        <p>The modal opens from the right and takes up the full available height.</p>
                     </BodyContent>
                 </BitModal>
             </div>
@@ -283,24 +259,20 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.AlertVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.AlertVisible"
-                          @attributes="context.Args"
-                          AriaLabel="Messaggio di notifica"
-                          >
+                <BitModal @bind-IsVisible="model.AlertVisible" @attributes="context.Args" AriaLabel="Notification message">
                     <HeaderContent>
                         <div class="d-flex align-items-center">
                             <BitIcon IconName="@Icons.ItWarningCircle" CssClass="me-2" />
-                            <h2 class="modal-title h5 mb-0">Questo è un messaggio di notifica</h2>
+                            <h2 class="modal-title h5 mb-0">This is a notification message</h2>
                         </div>
                     </HeaderContent>
                     <BodyContent>
-                        <p>In questo caso vengono forniti un pulsante di conferma e uno di chiusura della modale.</p>
+                        <p>In this case, a confirmation button and a close button are provided.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.AlertVisible = false">Ok</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.AlertVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -322,20 +294,15 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.PopconfirmBasicVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.PopconfirmBasicVisible"
-                          @attributes="context.Args"
-                          AriaLabel="Conferma azione"
-                          >
+                <BitModal @bind-IsVisible="model.PopconfirmBasicVisible" @attributes="context.Args" AriaLabel="Confirm action">
                     <BodyContent>
-                        <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
+                        <p>Font Titillium 14px. Leading 21px. Are you sure you want to proceed?</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button"
-                                @onclick="() => model.PopconfirmBasicVisible = false">Annulla</button>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.PopconfirmBasicVisible = false">Conferma</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button" @onclick="() => model.PopconfirmBasicVisible = false">Cancel</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.PopconfirmBasicVisible = false">Confirm</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -344,7 +311,7 @@
 
     <Story Name="Type - Popconfirm (with header)">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Intestazione Popconfirm")" />
+            <Arg For="_ => _.Title" Value="@("Popconfirm header")" />
             <Arg For="_ => _.Size" Value="ModalSize.Default" />
             <Arg For="_ => _.Position" Value="ModalPosition.Default" />
             <Arg For="_ => _.Type" Value="ModalType.Popconfirm" />
@@ -357,18 +324,15 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.PopconfirmHeaderVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.PopconfirmHeaderVisible"
-                          @attributes="context.Args">
+                <BitModal @bind-IsVisible="model.PopconfirmHeaderVisible" @attributes="context.Args">
                     <BodyContent>
-                        <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
+                        <p>Font Titillium 14px. Leading 21px. Are you sure you want to proceed?</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button"
-                                @onclick="() => model.PopconfirmHeaderVisible = false">Annulla</button>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.PopconfirmHeaderVisible = false">Conferma</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button" @onclick="() => model.PopconfirmHeaderVisible = false">Cancel</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.PopconfirmHeaderVisible = false">Confirm</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -390,18 +354,15 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.NoHeaderVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.NoHeaderVisible"
-                          @attributes="context.Args"
-                          AriaLabel="Finestra senza intestazione"
-                          >
+                <BitModal @bind-IsVisible="model.NoHeaderVisible" @attributes="context.Args" AriaLabel="Window without header">
                     <BodyContent>
-                        <p>Questa modale non ha intestazione. Usare <code>ShowCloseButton="false"</code> e non impostare <code>Title</code> o <code>HeaderContent</code>.</p>
+                        <p>This modal has no header. Use <code>ShowCloseButton="false"</code> and do not set <code>Title</code> or <code>HeaderContent</code>.
+                        </p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.NoHeaderVisible = false">Chiudi</button>
+                        <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.NoHeaderVisible = false">Close</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -410,7 +371,7 @@
 
     <Story Name="Scrollable content">
         <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale con contenuto scorrevole")" />
+            <Arg For="_ => _.Title" Value="@("Modal with scrollable content")" />
             <Arg For="_ => _.Size" Value="ModalSize.Default" />
             <Arg For="_ => _.Position" Value="ModalPosition.Default" />
             <Arg For="_ => _.Type" Value="ModalType.Default" />
@@ -423,96 +384,84 @@
         <Template>
             <div class="p-3">
                 <button class="btn btn-primary" type="button" @onclick="() => model.ScrollableVisible = true">
-                    Apri modale
+                    Open modal
                 </button>
-                <BitModal @bind-IsVisible="model.ScrollableVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi"
-                          >
+                <BitModal @bind-IsVisible="model.ScrollableVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
                     <BodyContent>
-                        <p>Testo molto lungo che causa lo scroll interno della modale.</p>
+                        <p>Very long text that causes the modal to scroll internally.</p>
                         @for (int i = 1; i <= 15; i++)
                         {
-                            <p>Paragrafo @i: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                            <p>Paragraph @i: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                         }
-                    </BodyContent>
-                    <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button"
-                                @onclick="() => model.ScrollableVisible = false">Annulla</button>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.ScrollableVisible = false">Conferma</button>
-                    </FooterContent>
-                </BitModal>
-            </div>
-        </Template>
-    </Story>
+                        </BodyContent>
+                        <FooterContent>
+                            <button class="btn btn-outline-primary btn-sm" type="button" @onclick="() => model.ScrollableVisible = false">Cancel</button>
+                            <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.ScrollableVisible = false">Confirm</button>
+                        </FooterContent>
+                    </BitModal>
+                </div>
+            </Template>
+        </Story>
 
-    <Story Name="Backdrop - Static">
-        <Arguments>
-            <Arg For="_ => _.Title" Value="@("Backdrop statico")" />
-            <Arg For="_ => _.Size" Value="ModalSize.Default" />
-            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
-            <Arg For="_ => _.Type" Value="ModalType.Default" />
-            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Static" />
-            <Arg For="_ => _.ShowCloseButton" Value="true" />
-            <Arg For="_ => _.ScrollableContent" Value="false" />
-            <Arg For="_ => _.FooterShadow" Value="false" />
-            <Arg For="_ => _.Fade" Value="true" />
-        </Arguments>
-        <Template>
-            <div class="p-3">
-                <button class="btn btn-primary" type="button" @onclick="() => model.StaticBackdropVisible = true">
-                    Apri modale
-                </button>
-                <BitModal @bind-IsVisible="model.StaticBackdropVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
-                    <BodyContent>
-                        <p>Con <code>Backdrop="ModalBackdrop.Static"</code> il clic sullo sfondo non chiude la modale.</p>
-                    </BodyContent>
-                    <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button"
-                                @onclick="() => model.StaticBackdropVisible = false">Annulla</button>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.StaticBackdropVisible = false">OK</button>
-                    </FooterContent>
-                </BitModal>
-            </div>
-        </Template>
-    </Story>
+        <Story Name="Backdrop - Static">
+            <Arguments>
+                <Arg For="_ => _.Title" Value="@("Static backdrop")" />
+                <Arg For="_ => _.Size" Value="ModalSize.Default" />
+                <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+                <Arg For="_ => _.Type" Value="ModalType.Default" />
+                <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Static" />
+                <Arg For="_ => _.ShowCloseButton" Value="true" />
+                <Arg For="_ => _.ScrollableContent" Value="false" />
+                <Arg For="_ => _.FooterShadow" Value="false" />
+                <Arg For="_ => _.Fade" Value="true" />
+            </Arguments>
+            <Template>
+                <div class="p-3">
+                    <button class="btn btn-primary" type="button" @onclick="() => model.StaticBackdropVisible = true">
+                        Open modal
+                    </button>
+                    <BitModal @bind-IsVisible="model.StaticBackdropVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
+                        <BodyContent>
+                            <p>With <code>Backdrop="ModalBackdrop.Static"</code>, clicking the background does not close the modal.</p>
+                        </BodyContent>
+                        <FooterContent>
+                            <button class="btn btn-outline-primary btn-sm" type="button" @onclick="() => model.StaticBackdropVisible = false">Cancel</button>
+                            <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.StaticBackdropVisible = false">OK</button>
+                        </FooterContent>
+                    </BitModal>
+                </div>
+            </Template>
+        </Story>
 
-    <Story Name="No animation (fade disabled)">
-        <Arguments>
-            <Arg For="_ => _.Title" Value="@("Modale senza animazione")" />
-            <Arg For="_ => _.Size" Value="ModalSize.Default" />
-            <Arg For="_ => _.Position" Value="ModalPosition.Default" />
-            <Arg For="_ => _.Type" Value="ModalType.Default" />
-            <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
-            <Arg For="_ => _.ShowCloseButton" Value="true" />
-            <Arg For="_ => _.ScrollableContent" Value="false" />
-            <Arg For="_ => _.FooterShadow" Value="false" />
-            <Arg For="_ => _.Fade" Value="false" />
-        </Arguments>
-        <Template>
-            <div class="p-3">
-                <button class="btn btn-primary" type="button" @onclick="() => model.NoFadeVisible = true">
-                    Apri modale
-                </button>
-                <BitModal @bind-IsVisible="model.NoFadeVisible"
-                          @attributes="context.Args"
-                          CloseButtonAriaLabel="Chiudi">
-                    <BodyContent>
-                        <p>La classe <code>fade</code> non viene applicata, quindi non c'è animazione di dissolvenza.</p>
-                    </BodyContent>
-                    <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button"
-                                @onclick="() => model.NoFadeVisible = false">OK</button>
-                    </FooterContent>
-                </BitModal>
-            </div>
-        </Template>
-    </Story>
-</Stories>
+        <Story Name="No animation (fade disabled)">
+            <Arguments>
+                <Arg For="_ => _.Title" Value="@("Modal without animation")" />
+                <Arg For="_ => _.Size" Value="ModalSize.Default" />
+                <Arg For="_ => _.Position" Value="ModalPosition.Default" />
+                <Arg For="_ => _.Type" Value="ModalType.Default" />
+                <Arg For="_ => _.Backdrop" Value="ModalBackdrop.Default" />
+                <Arg For="_ => _.ShowCloseButton" Value="true" />
+                <Arg For="_ => _.ScrollableContent" Value="false" />
+                <Arg For="_ => _.FooterShadow" Value="false" />
+                <Arg For="_ => _.Fade" Value="false" />
+            </Arguments>
+            <Template>
+                <div class="p-3">
+                    <button class="btn btn-primary" type="button" @onclick="() => model.NoFadeVisible = true">
+                        Open modal
+                    </button>
+                    <BitModal @bind-IsVisible="model.NoFadeVisible" @attributes="context.Args" CloseButtonAriaLabel="Close">
+                        <BodyContent>
+                            <p>The <code>fade</code> class is not applied, so there is no fade animation.</p>
+                        </BodyContent>
+                        <FooterContent>
+                            <button class="btn btn-primary btn-sm" type="button" @onclick="() => model.NoFadeVisible = false">OK</button>
+                        </FooterContent>
+                    </BitModal>
+                </div>
+            </Template>
+        </Story>
+    </Stories>
 
 @code {
     private ViewModel model = new();

--- a/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
+++ b/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
@@ -1,0 +1,276 @@
+@attribute [Stories("Components/BitModal")]
+
+@using BitBlazor.Components
+
+<Stories TComponent="BitModal">
+    <ArgType For="_ => _.Size" Control="ControlType.Select" DefaultValue="ModalSize.Default" />
+    <ArgType For="_ => _.Position" Control="ControlType.Select" DefaultValue="ModalPosition.Default" />
+    <ArgType For="_ => _.Type" Control="ControlType.Select" DefaultValue="ModalType.Default" />
+    <ArgType For="_ => _.Backdrop" Control="ControlType.Select" DefaultValue="ModalBackdrop.Default" />
+
+    <Story Name="Default">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Id="story-modal-default"
+                          Title="Intestazione modale"
+                          AriaDescribedById="story-modal-default-desc"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p id="story-modal-default-desc">Descrizione scopo della modale.</p>
+                        <p>Font Titillium 16px. Leading 24px. omnis iste natus error sit voluptatem accusantium.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
+                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="With close button">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Id="story-modal-closeable"
+                          Title="Intestazione modale"
+                          CloseButtonAriaLabel="Chiudi questa finestra">
+                    <BodyContent>
+                        <p>La modale può essere chiusa facendo clic sul pulsante X nell'intestazione.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
+                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Sizes - Small">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Size="ModalSize.Small"
+                          Title="Modale piccola"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>Questo è un esempio di modale di dimensione ridotta.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Sizes - Large">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Size="ModalSize.Large"
+                          Title="Modale grande"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>Questo è un esempio di modale di dimensione grande.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Sizes - Extra Large">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Size="ModalSize.ExtraLarge"
+                          Title="Modale molto grande"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>Questo è un esempio di modale di dimensione molto grande.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Position - Centered">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Position="ModalPosition.Centered"
+                          Title="Modale centrata"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>La modale è centrata verticalmente nella viewport.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Position - Left">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Position="ModalPosition.Left"
+                          Title="Modale a sinistra"
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
+                    <BodyContent>
+                        <p>La modale si apre da sinistra e occupa tutta l'altezza disponibile.</p>
+                    </BodyContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Position - Right">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Position="ModalPosition.Right"
+                          Title="Modale a destra"
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
+                    <BodyContent>
+                        <p>La modale si apre da destra e occupa tutta l'altezza disponibile.</p>
+                    </BodyContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Type - Alert (with icon)">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Type="ModalType.Alert"
+                          AriaLabel="Messaggio di notifica"
+                          ShowCloseButton="false">
+                    <HeaderContent>
+                        <div class="d-flex align-items-center">
+                            <BitIcon IconName="@Icons.ItWarningCircle" CssClass="me-2" />
+                            <h2 class="modal-title h5 mb-0">Questo è un messaggio di notifica</h2>
+                        </div>
+                    </HeaderContent>
+                    <BodyContent>
+                        <p>In questo caso vengono forniti un pulsante di conferma e uno di chiusura della modale.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-primary btn-sm" type="button">Ok</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Type - Popconfirm (basic)">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Type="ModalType.Popconfirm"
+                          AriaLabel="Conferma azione"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
+                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Type - Popconfirm (with header)">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Type="ModalType.Popconfirm"
+                          Title="Intestazione Popconfirm"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
+                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="No header">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          AriaLabel="Finestra senza intestazione"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>Questa modale non ha intestazione. Usare <code>ShowCloseButton="false"</code> e non impostare <code>Title</code> o <code>HeaderContent</code>.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-primary btn-sm" type="button">Chiudi</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Scrollable content">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          ScrollableContent="true"
+                          Title="Modale con contenuto scorrevole"
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi"
+                          FooterShadow="true">
+                    <BodyContent>
+                        <p>Testo molto lungo che causa lo scroll interno della modale.</p>
+                        @for (int i = 1; i <= 15; i++)
+                        {
+                            <p>Paragrafo @i: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                        }
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-outline-primary btn-sm" type="button">Annulla</button>
+                        <button class="btn btn-primary btn-sm" type="button">Conferma</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="No animation (fade disabled)">
+        <Template>
+            <div class="it-example-modal">
+                <BitModal IsVisible="true"
+                          Fade="false"
+                          Title="Modale senza animazione"
+                          ShowCloseButton="false">
+                    <BodyContent>
+                        <p>La classe <code>fade</code> non viene applicata, quindi non c'è animazione di dissolvenza.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+</Stories>

--- a/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
+++ b/stories/BitBlazor.Stories/Components/Stories/Components/BitModal.stories.razor
@@ -10,8 +10,11 @@
 
     <Story Name="Default">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.DefaultVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.DefaultVisible"
                           Id="story-modal-default"
                           Title="Intestazione modale"
                           AriaDescribedById="story-modal-default-desc"
@@ -21,8 +24,10 @@
                         <p>Font Titillium 16px. Leading 24px. omnis iste natus error sit voluptatem accusantium.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
-                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                @onclick="() => model.DefaultVisible = false">Annulla</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.DefaultVisible = false">Azione 1</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -31,8 +36,11 @@
 
     <Story Name="With close button">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.CloseButtonVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.CloseButtonVisible"
                           Id="story-modal-closeable"
                           Title="Intestazione modale"
                           CloseButtonAriaLabel="Chiudi questa finestra">
@@ -40,8 +48,10 @@
                         <p>La modale può essere chiusa facendo clic sul pulsante X nell'intestazione.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
-                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                @onclick="() => model.CloseButtonVisible = false">Annulla</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.CloseButtonVisible = false">Azione 1</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -50,16 +60,21 @@
 
     <Story Name="Sizes - Small">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.SizeSmallVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.SizeSmallVisible"
                           Size="ModalSize.Small"
                           Title="Modale piccola"
-                          ShowCloseButton="false">
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>Questo è un esempio di modale di dimensione ridotta.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.SizeSmallVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -68,16 +83,21 @@
 
     <Story Name="Sizes - Large">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.SizeLargeVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.SizeLargeVisible"
                           Size="ModalSize.Large"
                           Title="Modale grande"
-                          ShowCloseButton="false">
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>Questo è un esempio di modale di dimensione grande.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.SizeLargeVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -86,16 +106,21 @@
 
     <Story Name="Sizes - Extra Large">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.SizeXLVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.SizeXLVisible"
                           Size="ModalSize.ExtraLarge"
                           Title="Modale molto grande"
-                          ShowCloseButton="false">
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>Questo è un esempio di modale di dimensione molto grande.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.SizeXLVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -104,16 +129,21 @@
 
     <Story Name="Position - Centered">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.CenteredVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.CenteredVisible"
                           Position="ModalPosition.Centered"
                           Title="Modale centrata"
-                          ShowCloseButton="false">
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>La modale è centrata verticalmente nella viewport.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.CenteredVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -122,8 +152,11 @@
 
     <Story Name="Position - Left">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.LeftVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.LeftVisible"
                           Position="ModalPosition.Left"
                           Title="Modale a sinistra"
                           ShowCloseButton="true"
@@ -138,8 +171,11 @@
 
     <Story Name="Position - Right">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.RightVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.RightVisible"
                           Position="ModalPosition.Right"
                           Title="Modale a destra"
                           ShowCloseButton="true"
@@ -154,8 +190,11 @@
 
     <Story Name="Type - Alert (with icon)">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.AlertVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.AlertVisible"
                           Type="ModalType.Alert"
                           AriaLabel="Messaggio di notifica"
                           ShowCloseButton="false">
@@ -169,7 +208,8 @@
                         <p>In questo caso vengono forniti un pulsante di conferma e uno di chiusura della modale.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button">Ok</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.AlertVisible = false">Ok</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -178,8 +218,11 @@
 
     <Story Name="Type - Popconfirm (basic)">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.PopconfirmBasicVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.PopconfirmBasicVisible"
                           Type="ModalType.Popconfirm"
                           AriaLabel="Conferma azione"
                           ShowCloseButton="false">
@@ -187,8 +230,10 @@
                         <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
-                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                @onclick="() => model.PopconfirmBasicVisible = false">Annulla</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.PopconfirmBasicVisible = false">Conferma</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -197,8 +242,11 @@
 
     <Story Name="Type - Popconfirm (with header)">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.PopconfirmHeaderVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.PopconfirmHeaderVisible"
                           Type="ModalType.Popconfirm"
                           Title="Intestazione Popconfirm"
                           ShowCloseButton="false">
@@ -206,8 +254,10 @@
                         <p>Font Titillium 14px. Leading 21px. Sei sicuro di voler procedere?</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button">Azione 2</button>
-                        <button class="btn btn-primary btn-sm" type="button">Azione 1</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                @onclick="() => model.PopconfirmHeaderVisible = false">Annulla</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.PopconfirmHeaderVisible = false">Conferma</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -216,15 +266,19 @@
 
     <Story Name="No header">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.NoHeaderVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.NoHeaderVisible"
                           AriaLabel="Finestra senza intestazione"
                           ShowCloseButton="false">
                     <BodyContent>
                         <p>Questa modale non ha intestazione. Usare <code>ShowCloseButton="false"</code> e non impostare <code>Title</code> o <code>HeaderContent</code>.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button">Chiudi</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.NoHeaderVisible = false">Chiudi</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -233,8 +287,11 @@
 
     <Story Name="Scrollable content">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.ScrollableVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.ScrollableVisible"
                           ScrollableContent="true"
                           Title="Modale con contenuto scorrevole"
                           ShowCloseButton="true"
@@ -248,8 +305,35 @@
                         }
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-outline-primary btn-sm" type="button">Annulla</button>
-                        <button class="btn btn-primary btn-sm" type="button">Conferma</button>
+                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                @onclick="() => model.ScrollableVisible = false">Annulla</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.ScrollableVisible = false">Conferma</button>
+                    </FooterContent>
+                </BitModal>
+            </div>
+        </Template>
+    </Story>
+
+    <Story Name="Backdrop - Static">
+        <Template>
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.StaticBackdropVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.StaticBackdropVisible"
+                          Backdrop="ModalBackdrop.Static"
+                          Title="Backdrop statico"
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
+                    <BodyContent>
+                        <p>Con <code>Backdrop="ModalBackdrop.Static"</code> il clic sullo sfondo non chiude la modale.</p>
+                    </BodyContent>
+                    <FooterContent>
+                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                @onclick="() => model.StaticBackdropVisible = false">Annulla</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.StaticBackdropVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
@@ -258,19 +342,47 @@
 
     <Story Name="No animation (fade disabled)">
         <Template>
-            <div class="it-example-modal">
-                <BitModal IsVisible="true"
+            <div class="p-3">
+                <button class="btn btn-primary" type="button" @onclick="() => model.NoFadeVisible = true">
+                    Apri modale
+                </button>
+                <BitModal @bind-IsVisible="model.NoFadeVisible"
                           Fade="false"
                           Title="Modale senza animazione"
-                          ShowCloseButton="false">
+                          ShowCloseButton="true"
+                          CloseButtonAriaLabel="Chiudi">
                     <BodyContent>
                         <p>La classe <code>fade</code> non viene applicata, quindi non c'è animazione di dissolvenza.</p>
                     </BodyContent>
                     <FooterContent>
-                        <button class="btn btn-primary btn-sm" type="button">OK</button>
+                        <button class="btn btn-primary btn-sm" type="button"
+                                @onclick="() => model.NoFadeVisible = false">OK</button>
                     </FooterContent>
                 </BitModal>
             </div>
         </Template>
     </Story>
 </Stories>
+
+@code {
+    private ViewModel model = new();
+
+    class ViewModel
+    {
+        public bool DefaultVisible { get; set; }
+        public bool CloseButtonVisible { get; set; }
+        public bool SizeSmallVisible { get; set; }
+        public bool SizeLargeVisible { get; set; }
+        public bool SizeXLVisible { get; set; }
+        public bool CenteredVisible { get; set; }
+        public bool LeftVisible { get; set; }
+        public bool RightVisible { get; set; }
+        public bool AlertVisible { get; set; }
+        public bool PopconfirmBasicVisible { get; set; }
+        public bool PopconfirmHeaderVisible { get; set; }
+        public bool NoHeaderVisible { get; set; }
+        public bool ScrollableVisible { get; set; }
+        public bool StaticBackdropVisible { get; set; }
+        public bool NoFadeVisible { get; set; }
+    }
+}

--- a/tests/BitBlazor.Test/Components/Modal/BitModalTest.Behaviors.cs
+++ b/tests/BitBlazor.Test/Components/Modal/BitModalTest.Behaviors.cs
@@ -1,0 +1,83 @@
+using BitBlazor.Components;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace BitBlazor.Test.Components.Modal;
+
+public class BitModalTest
+{
+    private static RenderFragment SimpleBody =>
+        builder => builder.AddContent(0, "Body content");
+
+    [Fact]
+    public void BitModal_Should_Invoke_IsVisibleChanged_With_False_When_Close_Button_Is_Clicked()
+    {
+        using var ctx = new BunitContext();
+
+        bool newVisibility = true;
+        bool isVisibleChangedCalled = false;
+
+        var component = ctx.Render<BitModal>(parameters => parameters
+            .Add(p => p.IsVisible, true)
+            .Add(p => p.BodyContent, SimpleBody)
+            .Add(p => p.IsVisibleChanged, (v) => { isVisibleChangedCalled = true; newVisibility = v; }));
+
+        component.Find("button.btn-close").Click();
+
+        Assert.True(isVisibleChangedCalled);
+        Assert.False(newVisibility);
+    }
+
+    [Fact]
+    public void BitModal_Should_Invoke_OnClose_When_Close_Button_Is_Clicked()
+    {
+        using var ctx = new BunitContext();
+
+        bool onCloseCalled = false;
+
+        var component = ctx.Render<BitModal>(parameters => parameters
+            .Add(p => p.IsVisible, true)
+            .Add(p => p.BodyContent, SimpleBody)
+            .Add(p => p.OnClose, () => onCloseCalled = true));
+
+        component.Find("button.btn-close").Click();
+
+        Assert.True(onCloseCalled);
+    }
+
+    [Fact]
+    public void BitModal_Should_Invoke_IsVisibleChanged_With_False_When_Backdrop_Is_Clicked()
+    {
+        using var ctx = new BunitContext();
+
+        bool newVisibility = true;
+
+        var component = ctx.Render<BitModal>(parameters => parameters
+            .Add(p => p.IsVisible, true)
+            .Add(p => p.Backdrop, ModalBackdrop.Default)
+            .Add(p => p.BodyContent, SimpleBody)
+            .Add(p => p.IsVisibleChanged, (v) => newVisibility = v));
+
+        component.Find(".modal-backdrop").Click();
+
+        Assert.False(newVisibility);
+    }
+
+    [Fact]
+    public void BitModal_Should_Not_Invoke_IsVisibleChanged_When_Static_Backdrop_Is_Clicked()
+    {
+        using var ctx = new BunitContext();
+
+        bool isVisibleChangedCalled = false;
+
+        var component = ctx.Render<BitModal>(parameters => parameters
+            .Add(p => p.IsVisible, true)
+            .Add(p => p.Backdrop, ModalBackdrop.Static)
+            .Add(p => p.BodyContent, SimpleBody)
+            .Add(p => p.IsVisibleChanged, (v) => isVisibleChangedCalled = true));
+
+        component.Find(".modal-backdrop").Click();
+
+        Assert.False(isVisibleChangedCalled);
+    }
+}

--- a/tests/BitBlazor.Test/Components/Modal/BitModalTest.Behaviors.cs
+++ b/tests/BitBlazor.Test/Components/Modal/BitModalTest.Behaviors.cs
@@ -18,9 +18,8 @@ public class BitModalTest
         bool isVisibleChangedCalled = false;
 
         var component = ctx.Render<BitModal>(parameters => parameters
-            .Add(p => p.IsVisible, true)
-            .Add(p => p.BodyContent, SimpleBody)
-            .Add(p => p.IsVisibleChanged, (v) => { isVisibleChangedCalled = true; newVisibility = v; }));
+            .Bind(p => p.IsVisible, newVisibility, v => { isVisibleChangedCalled = true; newVisibility = v; })
+            .Add(p => p.BodyContent, SimpleBody));
 
         component.Find("button.btn-close").Click();
 
@@ -36,7 +35,7 @@ public class BitModalTest
         bool onCloseCalled = false;
 
         var component = ctx.Render<BitModal>(parameters => parameters
-            .Add(p => p.IsVisible, true)
+            .Bind(p => p.IsVisible, true, v => { })
             .Add(p => p.BodyContent, SimpleBody)
             .Add(p => p.OnClose, () => onCloseCalled = true));
 
@@ -53,10 +52,9 @@ public class BitModalTest
         bool newVisibility = true;
 
         var component = ctx.Render<BitModal>(parameters => parameters
-            .Add(p => p.IsVisible, true)
+            .Bind(p => p.IsVisible, newVisibility, v => newVisibility = v)
             .Add(p => p.Backdrop, ModalBackdrop.Default)
-            .Add(p => p.BodyContent, SimpleBody)
-            .Add(p => p.IsVisibleChanged, (v) => newVisibility = v));
+            .Add(p => p.BodyContent, SimpleBody));
 
         component.Find(".modal-backdrop").Click();
 
@@ -71,10 +69,9 @@ public class BitModalTest
         bool isVisibleChangedCalled = false;
 
         var component = ctx.Render<BitModal>(parameters => parameters
-            .Add(p => p.IsVisible, true)
+            .Bind(p => p.IsVisible, true, v => isVisibleChangedCalled = true)
             .Add(p => p.Backdrop, ModalBackdrop.Static)
-            .Add(p => p.BodyContent, SimpleBody)
-            .Add(p => p.IsVisibleChanged, (v) => isVisibleChangedCalled = true));
+            .Add(p => p.BodyContent, SimpleBody));
 
         component.Find(".modal-backdrop").Click();
 

--- a/tests/BitBlazor.Test/Components/Modal/BitModalTest.Rendering.razor
+++ b/tests/BitBlazor.Test/Components/Modal/BitModalTest.Rendering.razor
@@ -1,0 +1,327 @@
+@inherits BunitContext
+
+@code {
+    [Fact]
+    public void BitModal_Should_Not_Render_When_IsVisible_Is_False()
+    {
+        var component = Render(
+            @<BitModal IsVisible="false">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.Empty(component.Markup.Trim());
+    }
+
+    [Fact]
+    public void BitModal_Should_Render_When_IsVisible_Is_True()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.NotNull(component.Find(".modal"));
+        Assert.NotNull(component.Find(".modal-dialog"));
+        Assert.NotNull(component.Find(".modal-content"));
+        Assert.NotNull(component.Find(".modal-body"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Apply_Fade_Class_By_Default()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Contains("fade", modal.ClassList);
+    }
+
+    [Fact]
+    public void BitModal_Should_Not_Apply_Fade_Class_When_Fade_Is_False()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Fade="false">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.DoesNotContain("fade", modal.ClassList);
+    }
+
+    [Fact]
+    public void BitModal_Should_Apply_Show_Class_When_IsVisible_Is_True()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Contains("show", modal.ClassList);
+    }
+
+    [Theory]
+    [InlineData(ModalSize.Small, "modal-sm")]
+    [InlineData(ModalSize.Large, "modal-lg")]
+    [InlineData(ModalSize.ExtraLarge, "modal-xl")]
+    public void BitModal_Should_Apply_Size_Class_To_Dialog_Correctly(ModalSize size, string expectedClass)
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Size="@size">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var dialog = component.Find(".modal-dialog");
+        Assert.Contains(expectedClass, dialog.ClassList);
+    }
+
+    [Fact]
+    public void BitModal_Should_Apply_Centered_Position_Class_To_Dialog()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Position="ModalPosition.Centered">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var dialog = component.Find(".modal-dialog");
+        Assert.Contains("modal-dialog-centered", dialog.ClassList);
+    }
+
+    [Theory]
+    [InlineData(ModalPosition.Left, "modal-dialog-left")]
+    [InlineData(ModalPosition.Right, "modal-dialog-right")]
+    public void BitModal_Should_Apply_Left_Right_Position_Classes_And_Scrollable(ModalPosition position, string expectedDialogClass)
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Position="@position">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        var dialog = component.Find(".modal-dialog");
+
+        Assert.Contains(expectedDialogClass, dialog.ClassList);
+        Assert.Contains("it-dialog-scrollable", modal.ClassList);
+    }
+
+    [Theory]
+    [InlineData(ModalType.Alert, "alert-modal")]
+    [InlineData(ModalType.LinkList, "it-dialog-link-list")]
+    [InlineData(ModalType.Popconfirm, "popconfirm-modal")]
+    public void BitModal_Should_Apply_Type_Class_To_Modal_Correctly(ModalType type, string expectedClass)
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Type="@type">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Contains(expectedClass, modal.ClassList);
+    }
+
+    [Fact]
+    public void BitModal_Should_Render_Title_In_Header_H2()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Title="My Modal Title">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var title = component.Find("h2.modal-title");
+        Assert.Equal("My Modal Title", title.TextContent.Trim());
+    }
+
+    [Fact]
+    public void BitModal_Should_Set_Aria_LabelledBy_Pointing_To_Title_Element()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Id="test-modal" Title="My Title">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Equal("test-modal-title", modal.GetAttribute("aria-labelledby"));
+
+        var titleEl = component.Find("h2.modal-title");
+        Assert.Equal("test-modal-title", titleEl.Id);
+    }
+
+    [Fact]
+    public void BitModal_Should_Set_Aria_Label_When_Provided_And_No_Title()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" AriaLabel="Accessible label">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Equal("Accessible label", modal.GetAttribute("aria-label"));
+        Assert.Null(modal.GetAttribute("aria-labelledby"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Set_Aria_DescribedBy_When_Provided()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" AriaDescribedById="modal-desc">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Equal("modal-desc", modal.GetAttribute("aria-describedby"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Render_Close_Button_By_Default()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var closeButton = component.Find("button.btn-close");
+        Assert.Equal("Chiudi", closeButton.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Not_Render_Close_Button_When_ShowCloseButton_Is_False()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" ShowCloseButton="false">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.Throws<ElementNotFoundException>(() => component.Find("button.btn-close"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Use_Custom_Close_Button_Aria_Label()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" CloseButtonAriaLabel="Close dialog">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var closeButton = component.Find("button.btn-close");
+        Assert.Equal("Close dialog", closeButton.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Not_Render_Header_When_ShowCloseButton_False_And_No_Title()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" ShowCloseButton="false">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.Throws<ElementNotFoundException>(() => component.Find(".modal-header"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Render_Custom_Header_Content_When_Provided()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" ShowCloseButton="false">
+                <HeaderContent><h3 id="custom-heading">Custom Header</h3></HeaderContent>
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.NotNull(component.Find(".modal-header"));
+        Assert.Equal("Custom Header", component.Find("h3").TextContent.Trim());
+    }
+
+    [Fact]
+    public void BitModal_Should_Render_Footer_When_FooterContent_Is_Set()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true">
+                <BodyContent>Content</BodyContent>
+                <FooterContent><button type="button">OK</button></FooterContent>
+            </BitModal>);
+
+        Assert.NotNull(component.Find(".modal-footer"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Not_Render_Footer_When_FooterContent_Is_Not_Set()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.Throws<ElementNotFoundException>(() => component.Find(".modal-footer"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Apply_Footer_Shadow_Class_When_FooterShadow_Is_True()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" FooterShadow="true">
+                <BodyContent>Content</BodyContent>
+                <FooterContent>Footer</FooterContent>
+            </BitModal>);
+
+        var footer = component.Find(".modal-footer");
+        Assert.Contains("modal-footer-shadow", footer.ClassList);
+    }
+
+    [Fact]
+    public void BitModal_Should_Render_Backdrop_When_Backdrop_Is_Default()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Backdrop="ModalBackdrop.Default">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.NotNull(component.Find(".modal-backdrop"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Render_Backdrop_When_Backdrop_Is_Static()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Backdrop="ModalBackdrop.Static">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.NotNull(component.Find(".modal-backdrop"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Not_Render_Backdrop_When_Backdrop_Is_None()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" Backdrop="ModalBackdrop.None">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        Assert.Throws<ElementNotFoundException>(() => component.Find(".modal-backdrop"));
+    }
+
+    [Fact]
+    public void BitModal_Should_Apply_Scrollable_Class_When_ScrollableContent_Is_True()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" ScrollableContent="true">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Contains("it-dialog-scrollable", modal.ClassList);
+    }
+
+    [Fact]
+    public void BitModal_Should_Apply_Custom_Css_Class_To_Modal_Element()
+    {
+        var component = Render(
+            @<BitModal IsVisible="true" CssClass="my-custom-class">
+                <BodyContent>Content</BodyContent>
+            </BitModal>);
+
+        var modal = component.Find(".modal");
+        Assert.Contains("my-custom-class", modal.ClassList);
+    }
+}

--- a/tests/BitBlazor.Test/Components/Modal/BitModalTest.Rendering.razor
+++ b/tests/BitBlazor.Test/Components/Modal/BitModalTest.Rendering.razor
@@ -1,11 +1,14 @@
-@inherits BunitContext
+﻿@inherits BunitContext
 
 @code {
+    private bool _isVisible = true;
+
     [Fact]
     public void BitModal_Should_Not_Render_When_IsVisible_Is_False()
     {
+        _isVisible = false;
         var component = Render(
-            @<BitModal IsVisible="false">
+            @<BitModal @bind-IsVisible="@_isVisible">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -16,7 +19,7 @@
     public void BitModal_Should_Render_When_IsVisible_Is_True()
     {
         var component = Render(
-            @<BitModal IsVisible="true">
+            @<BitModal @bind-IsVisible="@_isVisible">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -30,7 +33,7 @@
     public void BitModal_Should_Apply_Fade_Class_By_Default()
     {
         var component = Render(
-            @<BitModal IsVisible="true">
+            @<BitModal @bind-IsVisible="@_isVisible">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -42,7 +45,7 @@
     public void BitModal_Should_Not_Apply_Fade_Class_When_Fade_Is_False()
     {
         var component = Render(
-            @<BitModal IsVisible="true" Fade="false">
+            @<BitModal @bind-IsVisible="@_isVisible" Fade="false">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -54,7 +57,7 @@
     public void BitModal_Should_Apply_Show_Class_When_IsVisible_Is_True()
     {
         var component = Render(
-            @<BitModal IsVisible="true">
+            @<BitModal @bind-IsVisible="@_isVisible">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -69,7 +72,7 @@
     public void BitModal_Should_Apply_Size_Class_To_Dialog_Correctly(ModalSize size, string expectedClass)
     {
         var component = Render(
-            @<BitModal IsVisible="true" Size="@size">
+            @<BitModal @bind-IsVisible="@_isVisible" Size="@size">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -81,7 +84,7 @@
     public void BitModal_Should_Apply_Centered_Position_Class_To_Dialog()
     {
         var component = Render(
-            @<BitModal IsVisible="true" Position="ModalPosition.Centered">
+            @<BitModal @bind-IsVisible="@_isVisible" Position="ModalPosition.Centered">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -95,7 +98,7 @@
     public void BitModal_Should_Apply_Left_Right_Position_Classes_And_Scrollable(ModalPosition position, string expectedDialogClass)
     {
         var component = Render(
-            @<BitModal IsVisible="true" Position="@position">
+            @<BitModal @bind-IsVisible="@_isVisible" Position="@position">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -113,7 +116,7 @@
     public void BitModal_Should_Apply_Type_Class_To_Modal_Correctly(ModalType type, string expectedClass)
     {
         var component = Render(
-            @<BitModal IsVisible="true" Type="@type">
+            @<BitModal @bind-IsVisible="@_isVisible" Type="@type">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -125,7 +128,7 @@
     public void BitModal_Should_Render_Title_In_Header_H2()
     {
         var component = Render(
-            @<BitModal IsVisible="true" Title="My Modal Title">
+            @<BitModal @bind-IsVisible="@_isVisible" Title="My Modal Title">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -137,7 +140,7 @@
     public void BitModal_Should_Set_Aria_LabelledBy_Pointing_To_Title_Element()
     {
         var component = Render(
-            @<BitModal IsVisible="true" Id="test-modal" Title="My Title">
+            @<BitModal @bind-IsVisible="@_isVisible" Id="test-modal" Title="My Title">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -152,7 +155,7 @@
     public void BitModal_Should_Set_Aria_Label_When_Provided_And_No_Title()
     {
         var component = Render(
-            @<BitModal IsVisible="true" AriaLabel="Accessible label">
+            @<BitModal @bind-IsVisible="@_isVisible" AriaLabel="Accessible label">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -165,7 +168,7 @@
     public void BitModal_Should_Set_Aria_DescribedBy_When_Provided()
     {
         var component = Render(
-            @<BitModal IsVisible="true" AriaDescribedById="modal-desc">
+            @<BitModal @bind-IsVisible="@_isVisible" AriaDescribedById="modal-desc">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -177,7 +180,7 @@
     public void BitModal_Should_Render_Close_Button_By_Default()
     {
         var component = Render(
-            @<BitModal IsVisible="true">
+            @<BitModal @bind-IsVisible="@_isVisible">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -189,7 +192,7 @@
     public void BitModal_Should_Not_Render_Close_Button_When_ShowCloseButton_Is_False()
     {
         var component = Render(
-            @<BitModal IsVisible="true" ShowCloseButton="false">
+            @<BitModal @bind-IsVisible="@_isVisible" ShowCloseButton="false">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -200,7 +203,7 @@
     public void BitModal_Should_Use_Custom_Close_Button_Aria_Label()
     {
         var component = Render(
-            @<BitModal IsVisible="true" CloseButtonAriaLabel="Close dialog">
+            @<BitModal @bind-IsVisible="@_isVisible" CloseButtonAriaLabel="Close dialog">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -212,7 +215,7 @@
     public void BitModal_Should_Not_Render_Header_When_ShowCloseButton_False_And_No_Title()
     {
         var component = Render(
-            @<BitModal IsVisible="true" ShowCloseButton="false">
+            @<BitModal @bind-IsVisible="@_isVisible" ShowCloseButton="false">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -223,7 +226,7 @@
     public void BitModal_Should_Render_Custom_Header_Content_When_Provided()
     {
         var component = Render(
-            @<BitModal IsVisible="true" ShowCloseButton="false">
+            @<BitModal @bind-IsVisible="@_isVisible" ShowCloseButton="false">
                 <HeaderContent><h3 id="custom-heading">Custom Header</h3></HeaderContent>
                 <BodyContent>Content</BodyContent>
             </BitModal>);
@@ -236,7 +239,7 @@
     public void BitModal_Should_Render_Footer_When_FooterContent_Is_Set()
     {
         var component = Render(
-            @<BitModal IsVisible="true">
+            @<BitModal @bind-IsVisible="@_isVisible">
                 <BodyContent>Content</BodyContent>
                 <FooterContent><button type="button">OK</button></FooterContent>
             </BitModal>);
@@ -248,7 +251,7 @@
     public void BitModal_Should_Not_Render_Footer_When_FooterContent_Is_Not_Set()
     {
         var component = Render(
-            @<BitModal IsVisible="true">
+            @<BitModal @bind-IsVisible="@_isVisible">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -259,7 +262,7 @@
     public void BitModal_Should_Apply_Footer_Shadow_Class_When_FooterShadow_Is_True()
     {
         var component = Render(
-            @<BitModal IsVisible="true" FooterShadow="true">
+            @<BitModal @bind-IsVisible="@_isVisible" FooterShadow="true">
                 <BodyContent>Content</BodyContent>
                 <FooterContent>Footer</FooterContent>
             </BitModal>);
@@ -272,7 +275,7 @@
     public void BitModal_Should_Render_Backdrop_When_Backdrop_Is_Default()
     {
         var component = Render(
-            @<BitModal IsVisible="true" Backdrop="ModalBackdrop.Default">
+            @<BitModal @bind-IsVisible="@_isVisible" Backdrop="ModalBackdrop.Default">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -283,7 +286,7 @@
     public void BitModal_Should_Render_Backdrop_When_Backdrop_Is_Static()
     {
         var component = Render(
-            @<BitModal IsVisible="true" Backdrop="ModalBackdrop.Static">
+            @<BitModal @bind-IsVisible="@_isVisible" Backdrop="ModalBackdrop.Static">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -294,7 +297,7 @@
     public void BitModal_Should_Not_Render_Backdrop_When_Backdrop_Is_None()
     {
         var component = Render(
-            @<BitModal IsVisible="true" Backdrop="ModalBackdrop.None">
+            @<BitModal @bind-IsVisible="@_isVisible" Backdrop="ModalBackdrop.None">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -305,7 +308,7 @@
     public void BitModal_Should_Apply_Scrollable_Class_When_ScrollableContent_Is_True()
     {
         var component = Render(
-            @<BitModal IsVisible="true" ScrollableContent="true">
+            @<BitModal @bind-IsVisible="@_isVisible" ScrollableContent="true">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 
@@ -317,7 +320,7 @@
     public void BitModal_Should_Apply_Custom_Css_Class_To_Modal_Element()
     {
         var component = Render(
-            @<BitModal IsVisible="true" CssClass="my-custom-class">
+            @<BitModal @bind-IsVisible="@_isVisible" CssClass="my-custom-class">
                 <BodyContent>Content</BodyContent>
             </BitModal>);
 


### PR DESCRIPTION
This pull request introduces significant improvements to the documentation and sample usage of the BitBlazor component library, focusing on Bootstrap Italia integration and modal/dialog functionality. The main changes include adding a comprehensive usage guide for the `BitModal` component, updating the documentation to clarify font usage, and providing a new sample page demonstrating notification and alert patterns.

**Documentation Enhancements:**

- Added a detailed usage guide for the `BitModal` component, including parameter tables, accessibility notes, usage examples, and references to Bootstrap Italia and WAI-ARIA best practices.
- Updated the `README.md` to recommend including the default Bootstrap Italia fonts via an additional stylesheet link, improving visual consistency.

**Sample Application Improvements:**

- Introduced a new sample page (`Comunicazioni.razor`) that demonstrates interactive notification cards, filtering, dismissible alerts, and an archive of past communications, showcasing practical use of BitBlazor components such as `BitModal`, `BitAlert`, `BitBadge`, and `BitCard`.