### PR TITLE
bugfix Updated BitBlazorTest dependencies - Closes #91

### DIFF
--- a/tests/BitBlazor.Test/BitBlazor.Test.csproj
+++ b/tests/BitBlazor.Test/BitBlazor.Test.csproj
@@ -8,17 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.common" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated BitBlazorTest dependencies:

- xUnit 2.9.3 -> 3.2.2
- MS.Net.Test.Sdk -> 18.8.1
- AngleSharp 1.4.0 (vulnerable) -> 1.5.2

Closes #91 